### PR TITLE
docs: adds docs for deploying new builds in testflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,48 @@ npx nx run-many -t <target1> <target2> -p <proj1> <proj2>
 ```
 
 Targets can be defined in the `package.json` or `projects.json`. Learn more [in the docs](https://nx.dev/features/run-tasks).
+
+## TestFlight
+
+### New Build
+
+```shell
+nx prebuild mobile-app -- --platform ios
+nx cargo-ios ironfish-native-module -- --target='ios'
+cd packages/mobile-app/ios
+pod install
+open .
+```
+
+- Double click .xcworkspace file (requires xcode)
+
+#### In XCode
+
+- Click folder icon in top left of editor
+- Double Click "mobileapp"
+- Signing & Capabilities tab
+- Under signing select "IF Labs" for team (must be added to team in App Store Connect, ask Derek)
+- Bundle identifier should be prepopulated but should read "com.ironfish.mobileapp"
+- In the scheme bar (top center of editor), select Any iOS Device (arm64)
+- Mac menu bar - click Product -> Archive, wait for build (might take a minute or two)
+- Click Distribute App button in popup
+- App Store Connect -> Distribute
+
+#### TestFlight website
+
+- Login at appstoreconnect.apple.com
+- Go to apps
+- Click Iron Fish Wallet
+- Click Test Flight tab
+- From here you can manage internal testing groups/members and builds
+
+### Adding Testflight user
+
+- For internal only, go to AppStoreConnect, Users and Access
+- Click +, enter email of employee that they use on their iOS device (probably not work email), add them as customer support
+- Have them verify joining team by checking email
+- Go to Apps -> Ironfish Wallet -> Testflight
+- Left panel Click Internal Testing IF Labs
+- Click + for testers
+- Select new user, click add
+- Have user go to email, and follow link to test app


### PR DESCRIPTION
Deployed first build and added myself (screenshot is from iPhone downloaded via testflight):

![Screenshot 2024-03-28 at 11 37 35 AM](https://github.com/iron-fish/mobile-wallet/assets/26990067/ef63ee42-86ea-48c9-a5ba-f9d9af213971)

