### PR TITLE
Fix decodeAccount in SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,6 +1798,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
 
 [[package]]
+name = "num"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,11 +1823,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2284,6 +2341,9 @@ name = "rust_lib"
 version = "0.0.1"
 dependencies = [
  "ironfish",
+ "num",
+ "num-derive",
+ "num-traits",
  "thiserror",
  "uniffi",
 ]

--- a/packages/ironfish-native-module/ios/IronfishNativeModule.swift
+++ b/packages/ironfish-native-module/ios/IronfishNativeModule.swift
@@ -30,7 +30,7 @@ public class IronfishNativeModule: Module {
     // The module will be accessible from `requireNativeModule('IronfishNativeModule')` in JavaScript.
     Name("IronfishNativeModule")
 
-    AsyncFunction("generateKey") { () -> ExpoKey in
+    Function("generateKey") { () -> ExpoKey in
       let k = generateKey()
 
       return ExpoKey(
@@ -43,7 +43,12 @@ public class IronfishNativeModule: Module {
       )
     }
 
-    AsyncFunction("generateKeyFromPrivateKey") { (privateKey: String) throws -> ExpoKey in
+    Function("wordsToSpendingKey") { (words: String, languageCode: Int32) throws -> String in
+      let k = try wordsToSpendingKey(words: words, languageCode: languageCode)
+      return k
+    }
+
+    Function("generateKeyFromPrivateKey") { (privateKey: String) throws -> ExpoKey in
       let k = try generateKeyFromPrivateKey(privateKey: privateKey)
 
       return ExpoKey(
@@ -54,6 +59,10 @@ public class IronfishNativeModule: Module {
         publicAddress: Field(wrappedValue: k.publicAddress),
         proofAuthorizingKey: Field(wrappedValue: k.proofAuthorizingKey)
       )
+    }
+
+    Function("isValidPublicAddress") { (hexAddress: String) -> Bool in
+      return isValidPublicAddress(hexAddress: hexAddress)
     }
   }
 }

--- a/packages/ironfish-native-module/rust_lib/Cargo.toml
+++ b/packages/ironfish-native-module/rust_lib/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 
 [dependencies]
 ironfish = { path = "../ironfish/ironfish-rust" }
+num = "0.4.1"
+num-derive = "0.4.2"
+num-traits = "0.2.18"
 thiserror = "1.0"
 uniffi = "0.26.1"
 

--- a/packages/ironfish-native-module/src/index.ts
+++ b/packages/ironfish-native-module/src/index.ts
@@ -11,12 +11,21 @@ export interface Key {
   proofAuthorizingKey: string;
 }
 
-export async function generateKey(): Promise<Key> {
-  return await IronfishNativeModule.generateKey();
+export function generateKey(): Key {
+  return IronfishNativeModule.generateKey();
 }
 
-export async function generateKeyFromPrivateKey(
-  privateKey: string,
-): Promise<Key> {
-  return await IronfishNativeModule.generateKeyFromPrivateKey(privateKey);
+export function wordsToSpendingKey(
+  words: string,
+  languageCode: number,
+): string {
+  return IronfishNativeModule.wordsToSpendingKey(words, languageCode);
+}
+
+export function generateKeyFromPrivateKey(privateKey: string): Key {
+  return IronfishNativeModule.generateKeyFromPrivateKey(privateKey);
+}
+
+export function isValidPublicAddress(hexAddress: string): boolean {
+  return IronfishNativeModule.isValidPublicAddress(hexAddress);
 }


### PR DESCRIPTION
Allows us to decode all account formats using decodeAccount from the SDK.

Fixes IFL-2425
Fixes IFL-2427
Fixes IFL-2454
