### PR TITLE
Demo using secure store with exportAccount

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14194,6 +14194,14 @@
         }
       }
     },
+    "node_modules/expo-secure-store": {
+      "version": "12.8.1",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-12.8.1.tgz",
+      "integrity": "sha512-Ju3jmkHby4w7rIzdYAt9kQyQ7HhHJ0qRaiQOInknhOLIltftHjEgF4I1UmzKc7P5RCfGNmVbEH729Pncp/sHXQ==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-splash-screen": {
       "version": "0.26.4",
       "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-0.26.4.tgz",
@@ -23358,6 +23366,7 @@
         "expo-constants": "~15.4.5",
         "expo-linking": "~6.2.2",
         "expo-router": "~3.4.8",
+        "expo-secure-store": "~12.8.1",
         "expo-sqlite": "~13.4.0",
         "expo-status-bar": "~1.11.1",
         "ironfish-native-module": "*",

--- a/packages/mobile-app/app.json
+++ b/packages/mobile-app/app.json
@@ -27,7 +27,8 @@
       "package": "com.ironfish.mobileapp"
     },
     "plugins": [
-      "expo-router"
+      "expo-router",
+      "expo-secure-store"
     ]
   }
 }

--- a/packages/mobile-app/app/(tabs)/transact.tsx
+++ b/packages/mobile-app/app/(tabs)/transact.tsx
@@ -1,4 +1,4 @@
-import { View, Text } from "react-native";
+import { View, Text, ScrollView, TextInput } from "react-native";
 import { useFacade } from "../../data/facades";
 import { Button } from "@ironfish/ui";
 import { useQueryClient } from "@tanstack/react-query";
@@ -15,12 +15,23 @@ export default function Transact() {
       })
     }
   });
+  const exportAccount = facade.exportAccount.useMutation();
 
   return (
-    <View>
+    <ScrollView>
       <Text>Accounts</Text>
       {(getAccountsResult.data ?? []).map((account) => (
-        <Text key={account.id}>{account.name}</Text>
+        <View key={account.id}>
+          <Text>{account.name}</Text>
+          <Button
+            onClick={async () => {
+              const otherResult = await exportAccount.mutateAsync({ name: account.name });
+              console.log('Exported Account:', otherResult)
+            }}
+          >
+          Export Account
+          </Button>
+        </View>
       ))}
       <Button
         onClick={async () => {
@@ -30,6 +41,6 @@ export default function Transact() {
       >
         Create Account
       </Button>
-    </View>
+    </ScrollView>
   );
 }

--- a/packages/mobile-app/data/facades/accounts/demoHandlers.ts
+++ b/packages/mobile-app/data/facades/accounts/demoHandlers.ts
@@ -35,4 +35,17 @@ export const accountsHandlers = f.facade<AccountsMethods>({
       ACCOUNTS.push(account);
       return account;
     }),
+  exportAccount: f.handler
+    .input(
+      z.object({
+        name: z.string(),
+      }),
+    )
+    .mutation(async ({ name }) => {
+      const account = ACCOUNTS.find((a) => a.name === name)
+      if (account === undefined) {
+        throw new Error("No accounts found");
+      }
+      return JSON.stringify(account);
+    }),
 });

--- a/packages/mobile-app/data/facades/accounts/handlers.ts
+++ b/packages/mobile-app/data/facades/accounts/handlers.ts
@@ -17,4 +17,14 @@ export const accountsHandlers = f.facade<AccountsMethods>({
       const account = await wallet.createAccount(name);
       return account;
     }),
+    exportAccount: f.handler
+    .input(
+      z.object({
+        name: z.string(),
+      }),
+    )
+    .mutation(async ({ name }) => {
+      const account = await wallet.exportAccount(name);
+      return account;
+    }),
 });

--- a/packages/mobile-app/data/facades/accounts/types.ts
+++ b/packages/mobile-app/data/facades/accounts/types.ts
@@ -9,4 +9,5 @@ export type Account = {
 export type AccountsMethods = {
   getAccounts: Query<() => Account[]>;
   createAccount: Mutation<(args: { name: string }) => Account>;
+  exportAccount: Mutation<(args: { name: string }) => string>;
 };

--- a/packages/mobile-app/data/wallet/db.ts
+++ b/packages/mobile-app/data/wallet/db.ts
@@ -65,6 +65,10 @@ export class WalletDb {
     }
 
     async getAccounts() {
-      return await this.db.selectFrom("accounts").selectAll('accounts').execute();
+      return await this.db.selectFrom("accounts").selectAll().execute();
+    }
+
+    async getAccount(name: string) {
+      return await this.db.selectFrom("accounts").selectAll().where('accounts.name', '==', name).executeTakeFirst();
     }
 }

--- a/packages/mobile-app/data/wallet/index.ts
+++ b/packages/mobile-app/data/wallet/index.ts
@@ -1,6 +1,7 @@
 import { generateKey } from "ironfish-native-module";
 import { WalletDb } from "./db";
-import { AccountFormat, encodeAccount } from "@ironfish/sdk";
+import { AccountFormat, decodeAccount, encodeAccount } from "@ironfish/sdk";
+import * as SecureStore from 'expo-secure-store'
 
 class Wallet {
   state: { type: 'STOPPED' } | { type: 'LOADING' } | { type: 'STARTED', db: WalletDb } = { type: 'STOPPED' };
@@ -41,7 +42,12 @@ class Wallet {
       name,
     }, AccountFormat.Base64Json)
 
-    return await this.state.db.createAccount(name, viewOnlyAccount)
+    const newAccount = await this.state.db.createAccount(name, viewOnlyAccount)
+    await SecureStore.setItemAsync(key.publicAddress, key.spendingKey, {
+      keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+      requireAuthentication: false,
+    });
+    return newAccount;
   }
 
   async getAccounts() {
@@ -50,6 +56,25 @@ class Wallet {
     }
 
     return this.state.db.getAccounts();
+  }
+
+  async exportAccount(name: string) {
+    if (this.state.type !== 'STARTED') {
+      throw new Error('Wallet is not started');
+    }
+
+    const account = await this.state.db.getAccount(name);
+    if (account == null) {
+      throw new Error(`No account found with name ${name}`)
+    }
+
+    const decodedAccount = decodeAccount(account.viewOnlyAccount);
+    decodedAccount.name = name;
+    decodedAccount.spendingKey = await SecureStore.getItemAsync(decodedAccount.publicAddress, {
+      keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+      requireAuthentication: false,
+    })
+    return encodeAccount(decodedAccount, AccountFormat.JSON)
   }
 }
 

--- a/packages/mobile-app/package.json
+++ b/packages/mobile-app/package.json
@@ -26,7 +26,8 @@
     "react-native": "0.73.6",
     "react-native-safe-area-context": "4.8.2",
     "react-native-screens": "~3.29.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "expo-secure-store": "~12.8.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
Demonstrates using expo-secure-store to store the spend key, and exportAccount to output the account + spend key.

exportAccount isn't complete yet, will add more parameters to make it similar to the RPC's version.
