### PR TITLE
Add spendingKeyToWords to ironfish-native-module

### DIFF
--- a/packages/ironfish-native-module/android/src/main/java/expo/modules/ironfishnativemodule/IronfishNativeModule.kt
+++ b/packages/ironfish-native-module/android/src/main/java/expo/modules/ironfishnativemodule/IronfishNativeModule.kt
@@ -41,6 +41,24 @@ class IronfishNativeModule : Module() {
       )
     }
 
+    Function("spendingKeyToWords") { privateKey: String, languageCode: Long ->
+      try {
+        return spendingKeyToWords(privateKey: privateKey, languageCode: languageCode)
+      } catch (error: Exception) {
+        error.printStackTrace()
+        throw error
+      }
+    }
+
+    Function("wordsToSpendingKey") { words: String, languageCode: Long ->
+      try {
+        return wordsToSpendingKey(words: words, languageCode: languageCode)
+      } catch (error: Exception) {
+        error.printStackTrace()
+        throw error
+      }
+    }
+
     AsyncFunction("generateKeyFromPrivateKey") { privateKey: String ->
       val k = uniffi.rust_lib.generateKeyFromPrivateKey(privateKey)
 
@@ -52,6 +70,15 @@ class IronfishNativeModule : Module() {
         k.publicAddress,
         k.proofAuthorizingKey
       )
+    }
+
+    Function("isValidPublicAddress") { hexAddress: String ->
+      try {
+        uniffi.rust_lib.isValidPublicAddress(hexAddress: hexAddress)
+      } catch (error: Exception) {
+        error.printStackTrace()
+        throw error
+      }
     }
   }
 }

--- a/packages/ironfish-native-module/ios/IronfishNativeModule.swift
+++ b/packages/ironfish-native-module/ios/IronfishNativeModule.swift
@@ -43,6 +43,11 @@ public class IronfishNativeModule: Module {
       )
     }
 
+    Function("spendingKeyToWords") { (privateKey: String, languageCode: Int32) throws -> String in
+      let phrase = try spendingKeyToWords(privateKey: privateKey, languageCode: languageCode)
+      return phrase
+    }
+
     Function("wordsToSpendingKey") { (words: String, languageCode: Int32) throws -> String in
       let k = try wordsToSpendingKey(words: words, languageCode: languageCode)
       return k

--- a/packages/ironfish-native-module/rust_lib/src/lib.rs
+++ b/packages/ironfish-native-module/rust_lib/src/lib.rs
@@ -67,6 +67,19 @@ fn generate_key() -> Key {
 }
 
 #[uniffi::export]
+pub fn spending_key_to_words(
+    private_key: String,
+    language_code: i32,
+) -> Result<String, EnumError> {
+    let key = SaplingKey::from_hex(&private_key).map_err(|e| EnumError::Error { msg: e.to_string() })?;
+    let language_code_enum: LanguageCode = LanguageCode::from_i32(language_code).ok_or_else(|| EnumError::Error { msg: "Invalid language code".to_string() })?;
+    let language = Language::from(language_code_enum);
+
+    let mnemonic = key.to_words(language).map_err(|e| EnumError::Error { msg: e.to_string() })?;
+    Ok(mnemonic.into_phrase())
+}
+
+#[uniffi::export]
 pub fn words_to_spending_key(
     words: String,
     language_code: i32,

--- a/packages/ironfish-native-module/src/index.ts
+++ b/packages/ironfish-native-module/src/index.ts
@@ -15,6 +15,13 @@ export function generateKey(): Key {
   return IronfishNativeModule.generateKey();
 }
 
+export function spendingKeyToWords(
+  privateKey: string,
+  languageCode: number,
+): string {
+  return IronfishNativeModule.spendingKeyToWords(privateKey, languageCode);
+}
+
 export function wordsToSpendingKey(
   words: string,
   languageCode: number,

--- a/packages/mobile-app/shims/ironfish-rust-nodejs.js
+++ b/packages/mobile-app/shims/ironfish-rust-nodejs.js
@@ -33,6 +33,7 @@ const mockIronfishRustNodejs = {
       throw new Error(message);
     }
   }),
+  spendingKeyToWords: IronfishNativeModule.spendingKeyToWords,
   wordsToSpendingKey: IronfishNativeModule.wordsToSpendingKey,
   generateKeyFromPrivateKey: IronfishNativeModule.generateKeyFromPrivateKey,
   isValidPublicAddress: IronfishNativeModule.isValidPublicAddress,


### PR DESCRIPTION
Adds spendingKeyToWords to the Rust native module and tests all the encodeAccount types to make sure they work.

Fixes IFL-2424
Fixes IFL-2426
