### PR TITLE
Load globals before expo-router

### DIFF
--- a/packages/mobile-app/app/(tabs)/contacts.tsx
+++ b/packages/mobile-app/app/(tabs)/contacts.tsx
@@ -1,5 +1,3 @@
-import "../../globals";
-
 import { Button } from "@ironfish/ui";
 import { View, Text } from "react-native";
 import { wallet } from "../../data/wallet/wallet";

--- a/packages/mobile-app/app/(tabs)/index.tsx
+++ b/packages/mobile-app/app/(tabs)/index.tsx
@@ -1,4 +1,3 @@
-import "../../globals";
 import { useState, useEffect } from "react";
 import { StatusBar } from "expo-status-bar";
 import { StyleSheet, Text, View } from "react-native";

--- a/packages/mobile-app/globals.ts
+++ b/packages/mobile-app/globals.ts
@@ -1,2 +1,0 @@
-global.Buffer = require("buffer").Buffer;
-global.process = require("process");

--- a/packages/mobile-app/index.js
+++ b/packages/mobile-app/index.js
@@ -1,5 +1,4 @@
-import 'expo-router/entry'
-// import { registerRootComponent } from 'expo';
-// import App from './App';
+global.Buffer = require('buffer').Buffer
+global.process = require('process')
 
-// registerRootComponent(App);
+import 'expo-router/entry'


### PR DESCRIPTION
We've occasionally run into problems with globals not actually being polyfilled for some reason. I saw it recommended here to load polyfills before expo-router: https://github.com/expo/expo/discussions/25122#discussioncomment-7433169
