### PR TITLE
Implement getTransaction in wallet

### DIFF
--- a/packages/mobile-app/data/facades/wallet/demoHandlers.ts
+++ b/packages/mobile-app/data/facades/wallet/demoHandlers.ts
@@ -149,10 +149,10 @@ export const walletDemoHandlers = f.facade<WalletHandlers>({
     }: {
       accountName: string;
       hash: string;
-    }): Promise<Transaction> => {
+    }): Promise<Transaction | null> => {
       return {
         hash: hash,
-        timestamp: new Date().setDate(new Date().getDate() - 1),
+        timestamp: new Date(new Date().setDate(new Date().getDate() - 1)),
         assetBalanceDeltas: [
           {
             assetId:
@@ -206,7 +206,7 @@ export const walletDemoHandlers = f.facade<WalletHandlers>({
       return [
         {
           hash: hash,
-          timestamp: new Date().setDate(new Date().getDate() - 1),
+          timestamp: new Date(new Date().setDate(new Date().getDate() - 1)),
           assetBalanceDeltas: [
             {
               assetId:

--- a/packages/mobile-app/data/facades/wallet/handlers.ts
+++ b/packages/mobile-app/data/facades/wallet/handlers.ts
@@ -155,9 +155,34 @@ export const walletHandlers = f.facade<WalletHandlers>({
     }: {
       accountName: string;
       hash: string;
-    }): Promise<Transaction> => {
-      // TODO: Implement getTransaction
-      throw new Error("getTransaction not yet implemented");
+    }): Promise<Transaction | null> => {
+      const txn = await wallet.getTransaction(
+        accountName,
+        Uint8ArrayUtils.fromHex(hash),
+      );
+
+      if (!txn) {
+        return null;
+      }
+
+      return {
+        // TODO: Implement transaction fees
+        fee: "",
+        timestamp: txn.timestamp,
+        // TODO: Implement transaction expiration
+        expiration: 0,
+        hash: Uint8ArrayUtils.toHex(txn.hash),
+        blockSequence: txn.blockSequence ?? undefined,
+        submittedSequence: 0,
+        assetBalanceDeltas: [],
+        status: TransactionStatus.CONFIRMED,
+        notes: [],
+        burns: [],
+        mints: [],
+        spends: [],
+        // TODO: Implement transaction type
+        type: TransactionType.RECEIVE,
+      };
     },
   ),
   getTransactions: f.handler.query(
@@ -179,7 +204,6 @@ export const walletHandlers = f.facade<WalletHandlers>({
       return txns.map((txn) => ({
         // TODO: Implement transaction fees
         fee: "",
-        // TODO: Implement transaction timestamp
         timestamp: txn.timestamp,
         // TODO: Implement transaction expiration
         expiration: 0,

--- a/packages/mobile-app/data/facades/wallet/types.ts
+++ b/packages/mobile-app/data/facades/wallet/types.ts
@@ -127,7 +127,7 @@ export type WalletHandlers = {
     }) => Transaction[]
   >;
   getTransaction: Query<
-    (args: { accountName: string; hash: string }) => Transaction
+    (args: { accountName: string; hash: string }) => Transaction | null
   >;
   getWalletStatus: Query<() => WalletStatus>;
   importAccount: Mutation<

--- a/packages/mobile-app/data/wallet/wallet.ts
+++ b/packages/mobile-app/data/wallet/wallet.ts
@@ -125,6 +125,17 @@ class Wallet {
     await this.state.db.removeAccount(name);
   }
 
+  async getTransaction(accountName: string, transactionHash: Uint8Array) {
+    assertStarted(this.state);
+
+    const account = await this.getAccount(accountName);
+    if (account == null) {
+      throw new Error(`No account found with name ${name}`);
+    }
+
+    return await this.state.db.getTransaction(account.id, transactionHash);
+  }
+
   async getTransactions(network: Network) {
     assertStarted(this.state);
 


### PR DESCRIPTION
The facade supports fetching a single transaction, and we should be able to return that now (barring fields that haven't been implemented yet)

Fixes IFL-2770
