### PR TITLE
Fetch transactions by account name

### DIFF
--- a/packages/mobile-app/app/(tabs)/index.tsx
+++ b/packages/mobile-app/app/(tabs)/index.tsx
@@ -1,19 +1,27 @@
 import { StatusBar } from "expo-status-bar";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
-import { Assert } from "@ironfish/sdk";
 import { useFacade } from "../../data/facades";
+import { useEffect, useState } from "react";
 
 export default function Balances() {
   const facade = useFacade();
 
+  const [account, setAccount] = useState<string>("");
+
   const getTransactionsResult = facade.getTransactions.useQuery(
-    { accountName: "", hash: "" },
+    { accountName: account, hash: "" },
     {
       refetchInterval: 1000,
     },
   );
 
-  Assert.isEqual(50, 50);
+  const getAccountsResult = facade.getAccounts.useQuery();
+
+  useEffect(() => {
+    if (getAccountsResult.data) {
+      setAccount(getAccountsResult.data[0].name);
+    }
+  }, [getAccountsResult.data]);
 
   return (
     <View style={styles.container}>

--- a/packages/mobile-app/data/facades/wallet/demoHandlers.ts
+++ b/packages/mobile-app/data/facades/wallet/demoHandlers.ts
@@ -191,10 +191,8 @@ export const walletDemoHandlers = f.facade<WalletHandlers>({
   getTransactions: f.handler.query(
     async ({
       accountName,
-      hash,
     }: {
       accountName: string;
-      hash: string;
       options?: {
         limit?: number;
         offset?: number;
@@ -205,7 +203,7 @@ export const walletDemoHandlers = f.facade<WalletHandlers>({
     }): Promise<Transaction[]> => {
       return [
         {
-          hash: hash,
+          hash: "4343291950e34661d8a89114dd77524ad95e7cb78fe50d29f1c9067adc1c2d4c",
           timestamp: new Date(new Date().setDate(new Date().getDate() - 1)),
           assetBalanceDeltas: [
             {

--- a/packages/mobile-app/data/facades/wallet/handlers.ts
+++ b/packages/mobile-app/data/facades/wallet/handlers.ts
@@ -200,10 +200,8 @@ export const walletHandlers = f.facade<WalletHandlers>({
   getTransactions: f.handler.query(
     async ({
       accountName,
-      hash,
     }: {
       accountName: string;
-      hash: string;
       options?: {
         limit?: number;
         offset?: number;
@@ -212,7 +210,7 @@ export const walletHandlers = f.facade<WalletHandlers>({
         address?: string;
       };
     }): Promise<Transaction[]> => {
-      const txns = await wallet.getTransactions(Network.TESTNET);
+      const txns = await wallet.getTransactions(accountName, Network.TESTNET);
 
       // TODO: Make a better query for this
       const txnsWithNotes = await Promise.all(

--- a/packages/mobile-app/data/facades/wallet/types.ts
+++ b/packages/mobile-app/data/facades/wallet/types.ts
@@ -116,7 +116,6 @@ export type WalletHandlers = {
   getTransactions: Query<
     (args: {
       accountName: string;
-      hash: string;
       options?: {
         limit?: number;
         offset?: number;

--- a/packages/mobile-app/data/wallet/db.ts
+++ b/packages/mobile-app/data/wallet/db.ts
@@ -5,7 +5,6 @@ import * as SecureStore from "expo-secure-store";
 import { AccountFormat, encodeAccount, Note } from "@ironfish/sdk";
 import { Network } from "../constants";
 import * as Uint8ArrayUtils from "../../utils/uint8Array";
-
 interface AccountsTable {
   id: Generated<number>;
   name: string;
@@ -462,12 +461,19 @@ export class WalletDb {
       .execute();
   }
 
-  async getTransactions(network: Network) {
+  async getTransactions(accountId: number, network: Network) {
     return await this.db
-      .selectFrom("transactions")
+      .selectFrom("accountTransactions")
+      .innerJoin(
+        "transactions",
+        "transactions.hash",
+        "accountTransactions.transactionHash",
+      )
       .selectAll()
-      .where("network", "=", network)
-      .orderBy("timestamp", "asc")
+      .where((eb) =>
+        eb.and([eb("accountId", "=", accountId), eb("network", "=", network)]),
+      )
+      .orderBy("transactions.timestamp", "asc")
       .execute();
   }
 }

--- a/packages/mobile-app/data/wallet/wallet.ts
+++ b/packages/mobile-app/data/wallet/wallet.ts
@@ -143,10 +143,15 @@ class Wallet {
     return await this.state.db.getTransactionNotes(transactionHash);
   }
 
-  async getTransactions(network: Network) {
+  async getTransactions(accountName: string, network: Network) {
     assertStarted(this.state);
 
-    return await this.state.db.getTransactions(network);
+    const account = await this.getAccount(accountName);
+    if (account == null) {
+      throw new Error(`No account found with name ${accountName}`);
+    }
+
+    return await this.state.db.getTransactions(account.id, network);
   }
 
   private async connectBlock(


### PR DESCRIPTION
Update getTransactions facade handler to fetch transactions by account name.

Fixes IFL-2771
