### PR TITLE
Change some native parameters to objects

### DIFF
--- a/packages/ironfish-native-module/src/index.ts
+++ b/packages/ironfish-native-module/src/index.ts
@@ -53,45 +53,56 @@ export function isValidPublicAddress(hexAddress: string): boolean {
   return IronfishNativeModule.isValidPublicAddress(hexAddress);
 }
 
-export function unpackGzip(
-  gzipPath: string,
-  outputPath: string,
-): Promise<boolean> {
+export function unpackGzip({
+  gzipPath,
+  outputPath,
+}: {
+  gzipPath: string;
+  outputPath: string;
+}): Promise<boolean> {
   return IronfishNativeModule.unpackGzip(gzipPath, outputPath);
 }
 
-export function readPartialFile(
-  path: string,
-  offset: number,
-  length: number,
-): Promise<Uint8Array> {
+export function readPartialFile({
+  path,
+  offset,
+  length,
+}: {
+  path: string;
+  offset: number;
+  length: number;
+}): Promise<Uint8Array> {
   return IronfishNativeModule.readPartialFile(path, offset, length);
 }
 
 export function decryptNotesForOwner(
-  noteEncrypted: string[],
+  encryptedNotes: string[],
   incomingHexKey: string,
 ): Promise<{ index: number; note: string }[]> {
   return IronfishNativeModule.decryptNotesForOwner(
-    noteEncrypted,
+    encryptedNotes,
     incomingHexKey,
   );
 }
 
 export function decryptNotesForSpender(
-  noteEncrypted: string[],
+  encryptedNotes: string[],
   outgoingHexKey: string,
 ): Promise<{ index: number; note: string }[]> {
   return IronfishNativeModule.decryptNotesForSpender(
-    noteEncrypted,
+    encryptedNotes,
     outgoingHexKey,
   );
 }
 
-export function nullifier(
-  note: string,
-  position: string,
-  viewKey: string,
-): Promise<string> {
-  return IronfishNativeModule.nullifier(note, position, viewKey);
+export function nullifier({
+  note,
+  position,
+  viewHexKey,
+}: {
+  note: string;
+  position: string;
+  viewHexKey: string;
+}): Promise<string> {
+  return IronfishNativeModule.nullifier(note, position, viewHexKey);
 }

--- a/packages/mobile-app/data/api/walletServerChunks.ts
+++ b/packages/mobile-app/data/api/walletServerChunks.ts
@@ -106,7 +106,10 @@ class WalletServerChunks {
     if (result.status !== 200) {
       console.warn("Unhandled status code", result.status);
     }
-    await unpackGzip(directory + file + ".gz", directory + file);
+    await unpackGzip({
+      gzipPath: directory + file + ".gz",
+      outputPath: directory + file,
+    });
   }
 
   /**
@@ -159,11 +162,11 @@ class WalletServerChunks {
       const start = ranges[pos][1];
       const end = ranges[endIndex][2];
       // TODO: start the next read while decoding
-      const bytes = await readPartialFile(
-        directory + file,
-        start,
-        end - start + 1,
-      );
+      const bytes = await readPartialFile({
+        path: directory + file,
+        offset: start,
+        length: end - start + 1,
+      });
 
       for (let i = pos; i <= endIndex; i++) {
         const block = LightBlock.decode(

--- a/packages/mobile-app/data/wallet/wallet.ts
+++ b/packages/mobile-app/data/wallet/wallet.ts
@@ -281,11 +281,11 @@ class Wallet {
 
       const note = new Note(Buffer.from(Uint8ArrayUtils.fromHex(result.note)));
       const position = startingNoteIndex + result.index;
-      const nullifier = await IronfishNativeModule.nullifier(
-        Uint8ArrayUtils.toHex(note.serialize()),
-        position.toString(),
+      const nullifier = await IronfishNativeModule.nullifier({
+        note: Uint8ArrayUtils.toHex(note.serialize()),
+        position: position.toString(),
         viewHexKey,
-      );
+      });
 
       const hexHash = Uint8ArrayUtils.toHex(transaction.hash);
       const txnStore = transactions.get(hexHash);


### PR DESCRIPTION
Changes some of the parameters in the native modules to use objects instead.

Some of the functions are used by the `ironfish-rust-nodejs` shim to allow for account importing, so I could change those as well for consistency, but it would make the shim file a bit more complicated.
