### PR TITLE
Pass in transaction version from SDK

### DIFF
--- a/packages/ironfish-native-module/ios/IronfishNativeModule.swift
+++ b/packages/ironfish-native-module/ios/IronfishNativeModule.swift
@@ -157,13 +157,13 @@ public class IronfishNativeModule: Module {
       }
     }
 
-    AsyncFunction("createTransaction") { (spendComponents: SpendComponentsInput, outputs: OutputsInput, spendingKey: Data) throws  -> Data in
+    AsyncFunction("createTransaction") { (transactionVersion: UInt8, spendComponents: SpendComponentsInput, outputs: OutputsInput, spendingKey: Data) throws  -> Data in
       let spendComponentsConverted = spendComponents.components.map { spendComponent in
           let witnessAuthPath: [WitnessNode] = spendComponent.witnessAuthPath.map { WitnessNode(side: $0.side, hashOfSibling: Data(hexString: $0.hashOfSibling)!) }
           return SpendComponents(note: Data(hexString: spendComponent.note)!, witnessRootHash: Data(hexString: spendComponent.witnessRootHash)!, witnessTreeSize: UInt64(spendComponent.witnessTreeSize)!, witnessAuthPath: witnessAuthPath)
       }
       do {
-        let transaction = try createTransaction(spendComponents: spendComponentsConverted, outputs: outputs.outputs.map {Data(hexString: $0)!}, spendingKey: spendingKey)
+        let transaction = try createTransaction(transactionVersion: transactionVersion, spendComponents: spendComponentsConverted, outputs: outputs.outputs.map {Data(hexString: $0)!}, spendingKey: spendingKey)
           return transaction
       } catch let error as NSError {
           print("Unexpected error: \(error.debugDescription)")

--- a/packages/ironfish-native-module/rust_lib/src/lib.rs
+++ b/packages/ironfish-native-module/rust_lib/src/lib.rs
@@ -338,12 +338,17 @@ pub fn create_note(params: NoteParams) -> Result<Vec<u8>, EnumError> {
 
 #[uniffi::export]
 pub fn create_transaction(
+    transaction_version: u8,
     spend_components: Vec<SpendComponents>,
     outputs: Vec<Vec<u8>>,
     spending_key: Vec<u8>,
 ) -> Result<Vec<u8>, EnumError> {
-    let mut transaction =
-        ironfish::ProposedTransaction::new(ironfish::transaction::TransactionVersion::V2);
+    let version = ironfish::transaction::TransactionVersion::from_u8(transaction_version)
+        .ok_or_else(|| EnumError::Error {
+            msg: "Invalid transaction version".to_string(),
+        })?;
+
+    let mut transaction = ironfish::ProposedTransaction::new(version);
     for spend_component in spend_components {
         let note_data = Cursor::new(spend_component.note);
         let note =

--- a/packages/ironfish-native-module/src/index.ts
+++ b/packages/ironfish-native-module/src/index.ts
@@ -124,6 +124,7 @@ export function createNote({
 }
 
 export function createTransaction(
+  transactionVersion: number,
   spendComponents: {
     note: string;
     witnessRootHash: string;
@@ -134,6 +135,7 @@ export function createTransaction(
   spendingKey: Uint8Array,
 ): Promise<Uint8Array> {
   return IronfishNativeModule.createTransaction(
+    transactionVersion,
     { components: spendComponents },
     { outputs },
     spendingKey,

--- a/packages/mobile-app/app/send/index.tsx
+++ b/packages/mobile-app/app/send/index.tsx
@@ -35,7 +35,7 @@ export default function Send() {
       {getAccountResult.data?.balances.custom.map((b) => (
         <Button
           key={b.assetId}
-          title={`${b.assetId} (${getAccountResult.data?.balances.iron.confirmed ?? 0}) ${selectedAssetId === b.assetId ? "(selected)" : ""}`}
+          title={`${b.assetId} (${b.confirmed ?? 0}) ${selectedAssetId === b.assetId ? "(selected)" : ""}`}
           onPress={() => setSelectedAssetId(b.assetId)}
         />
       ))}


### PR DESCRIPTION
This aligns behavior of the mobile wallet with that of the standalone wallet, but we should probably be fetching the transaction version from the wallet-server instead of the SDK. That would make it easier to ship activation sequence hardforks.

Fixes IFL-2902
