### PR TITLE
Makes button component take children

### DIFF
--- a/packages/mobile-app/app/(tabs)/ui.tsx
+++ b/packages/mobile-app/app/(tabs)/ui.tsx
@@ -23,10 +23,16 @@ export default function UiKit() {
       }}
     >
       <Text size="lg">Count: {count}</Text>
-      <Button title="Press me" onClick={() => setCount(count + 1)} />
+      <Button onClick={() => setCount(count + 1)}>
+        <Text>Press me</Text>
+      </Button>
       <Box height="auto" bg="pink" borderWidth={2} borderColor="gray">
-        <Button title="Press me" onClick={() => setCount(count + 1)} />
-        <Button disabled title="Press me" onClick={() => setCount(count + 1)} />
+        <Button onClick={() => setCount(count + 1)}>
+          <Text>Press me</Text>
+        </Button>
+        <Button disabled onClick={() => setCount(count + 1)}>
+          <Text>You can't press me</Text>
+        </Button>
       </Box>
       <Text>Input value: {inputValue}</Text>
       <TextInput
@@ -48,8 +54,12 @@ export default function UiKit() {
         borderWidth={8}
         borderColor="gray"
       >
-        <Button title="Press me" onClick={() => setCount(count + 1)} />
-        <Button disabled title="Press me" onClick={() => setCount(count + 1)} />
+        <Button onClick={() => setCount(count + 1)}>
+          <Text>Press me</Text>
+        </Button>
+        <Button disabled onClick={() => setCount(count + 1)}>
+          <Text>You can't press me</Text>
+        </Button>
       </HStack>
 
       <VStack
@@ -59,8 +69,12 @@ export default function UiKit() {
         borderWidth={4}
         borderColor="black"
       >
-        <Button title="Press me" onClick={() => setCount(count + 1)} />
-        <Button disabled title="Press me" onClick={() => setCount(count + 1)} />
+        <Button onClick={() => setCount(count + 1)}>
+          <Text>Press me</Text>
+        </Button>
+        <Button disabled onClick={() => setCount(count + 1)}>
+          <Text>You can't press me</Text>
+        </Button>
       </VStack>
     </View>
   );

--- a/packages/tackle-box/lib/components/Button/Button.tsx
+++ b/packages/tackle-box/lib/components/Button/Button.tsx
@@ -1,6 +1,5 @@
 import { html, css } from "react-strict-dom";
 import { ComponentProps } from "react";
-import { Text } from "@/components/Text/Text";
 
 const colors = css.defineVars({
   black: "#000",
@@ -36,11 +35,11 @@ const styles = css.create({
 type ButtonProps = ComponentProps<typeof html.button>;
 
 type Props = Pick<ButtonProps, "onClick"> & {
-  title: string;
+  children: React.ReactNode;
   disabled?: boolean;
 };
 
-export function Button({ title, disabled, onClick }: Props) {
+export function Button({ disabled, onClick, children }: Props) {
   return (
     <html.button
       style={[styles.base, disabled && styles.disabled]}
@@ -49,7 +48,7 @@ export function Button({ title, disabled, onClick }: Props) {
         onClick?.(e);
       }}
     >
-      <Text>{title}</Text>
+      {children}
     </html.button>
   );
 }


### PR DESCRIPTION
Instead of adding props such as `leftIcon, rightIcon, title` I opted to adjust button to render children - this gives us much more flexibility within the component. The con of this is that is is slightly more code of having to render a <Text> component or could allow for some anti-patterns if the dev decides to render something like an Anchor within the button