### PR TITLE
Add oreowallet auth header to calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12882,6 +12882,18 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-crypto": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-14.0.2.tgz",
+      "integrity": "sha512-WRc9PBpJraJN29VD5Ef7nCecxJmZNyRKcGkNiDQC1nhY5agppzwhqh7zEzNFarE/GqDgSiaDHS8yd5EgFhP9AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-file-system": {
       "version": "18.0.7",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.0.7.tgz",
@@ -23661,6 +23673,7 @@
         "data-facade": "*",
         "expo": "^52.0.0",
         "expo-constants": "~17.0.4",
+        "expo-crypto": "~14.0.2",
         "expo-font": "~13.0.3",
         "expo-linear-gradient": "~14.0.2",
         "expo-linking": "~7.0.4",

--- a/packages/mobile-app/app/(tabs)/index.tsx
+++ b/packages/mobile-app/app/(tabs)/index.tsx
@@ -64,9 +64,13 @@ export default function Balances() {
     },
   );
 
-  const getWalletStatusResult = facade.getWalletStatus.useQuery(undefined, {
-    refetchInterval: 5000,
-  });
+  const getWalletStatusResult = facade.getWalletStatus.useQuery(
+    { accountName: account },
+    {
+      refetchInterval: 5000,
+      enabled: account !== "",
+    },
+  );
 
   useEffect(() => {
     if (getAccountResult.data) {

--- a/packages/mobile-app/app/menu/debug/index.tsx
+++ b/packages/mobile-app/app/menu/debug/index.tsx
@@ -1,6 +1,5 @@
 import { StatusBar } from "expo-status-bar";
-import { Button, StyleSheet, Text, View } from "react-native";
-import { useFacade } from "../../../data/facades";
+import { Button, StyleSheet, View } from "react-native";
 import { Network } from "../../../data/constants";
 import { wallet } from "../../../data/wallet/wallet";
 import { reverseScan } from "../../../data/debug/reverseScan";

--- a/packages/mobile-app/app/menu/debug/index.tsx
+++ b/packages/mobile-app/app/menu/debug/index.tsx
@@ -7,40 +7,12 @@ import { reverseScan } from "../../../data/debug/reverseScan";
 import { LinkButton } from "../../../components/LinkButton";
 
 export default function MenuDebug() {
-  const facade = useFacade();
-
-  const walletStatus = facade.getWalletStatus.useQuery(undefined, {
-    refetchInterval: 1000,
-  });
-
-  const pauseSyncing = facade.pauseSyncing.useMutation();
-  const resumeSyncing = facade.resumeSyncing.useMutation();
-
   return (
     <View style={styles.container}>
       <LinkButton title="Pending Transactions" href="/menu/debug/pending/" />
       <LinkButton title="Unspent Notes" href="/menu/debug/unspent/" />
       <LinkButton title="Oreowallet" href="/menu/debug/oreowallet/" />
       <View>
-        {walletStatus.data && (
-          <>
-            <Text>{`Scan status: ${walletStatus.data.status}`}</Text>
-            <Text>{`Latest known block: ${walletStatus.data.latestKnownBlock}`}</Text>
-          </>
-        )}
-        <Text>{}</Text>
-        <Button
-          onPress={() => {
-            resumeSyncing.mutate(undefined);
-          }}
-          title="Resume Syncing"
-        />
-        <Button
-          onPress={() => {
-            pauseSyncing.mutateAsync(undefined);
-          }}
-          title="Pause Syncing"
-        />
         <Button
           onPress={async () => {
             await reverseScan(wallet, Network.TESTNET);

--- a/packages/mobile-app/app/menu/debug/oreowallet.tsx
+++ b/packages/mobile-app/app/menu/debug/oreowallet.tsx
@@ -16,131 +16,150 @@ export default function MenuDebugOreowallet() {
 
   const exportAccountMutation = facade.exportAccount.useMutation();
 
+  const getAccountInfo = async (name: string) => {
+    const es = await exportAccountMutation.mutateAsync({
+      name,
+      format: AccountFormat.Base64Json,
+      viewOnly: true,
+    });
+
+    const acc = decodeAccount(es);
+
+    return { publicAddress: acc.publicAddress, viewKey: acc.viewKey };
+  };
+
   return (
     <View style={styles.container}>
       <View>
-        <Text>{account.data?.name}</Text>
-        <Button
-          onPress={async () => {
-            if (!account.data) return;
+        <Text>{`Account: ${account.data?.name}`}</Text>
+        {account.data && (
+          <>
+            <Button
+              onPress={async () => {
+                if (!account.data) return;
 
-            const exported = await exportAccountMutation.mutateAsync({
-              name: account.data.name,
-              format: AccountFormat.JSON,
-              viewOnly: true,
-            });
-            const decoded = decodeAccount(exported);
+                const exported = await exportAccountMutation.mutateAsync({
+                  name: account.data.name,
+                  format: AccountFormat.JSON,
+                  viewOnly: true,
+                });
+                const decoded = decodeAccount(exported);
 
-            const result = await OreowalletServerApi.importAccount(
-              Network.MAINNET,
-              {
-                viewKey: decoded.viewKey,
-                incomingViewKey: decoded.incomingViewKey,
-                outgoingViewKey: decoded.outgoingViewKey,
-                publicAddress: decoded.publicAddress,
-              },
-            );
-            console.log(JSON.stringify(result));
-          }}
-          title="Import Account"
-        />
-        <Button
-          onPress={async () => {
-            if (!account.data) return;
-
-            const result = await OreowalletServerApi.getAccountStatus(
-              Network.MAINNET,
-              { address: account.data.publicAddress },
-            );
-            console.log(JSON.stringify(result));
-          }}
-          title="Get Account Status"
-        />
-        <Button
-          onPress={async () => {
-            if (!account.data) return;
-
-            const result = await OreowalletServerApi.getTransactions(
-              Network.MAINNET,
-              account.data.publicAddress,
-            );
-            console.log(JSON.stringify(result));
-          }}
-          title="Get Transactions"
-        />
-        <Button
-          onPress={async () => {
-            if (!account.data) return;
-
-            const result = await OreowalletServerApi.createTransaction(
-              Network.MAINNET,
-              account.data.publicAddress,
-              {
-                outputs: [
+                const result = await OreowalletServerApi.importAccount(
+                  Network.MAINNET,
                   {
-                    // TODO: Insert an address here
-                    publicAddress: "",
-                    amount: "100",
-                    assetId: IRON_ASSET_ID_HEX,
+                    viewKey: decoded.viewKey,
+                    incomingViewKey: decoded.incomingViewKey,
+                    outgoingViewKey: decoded.outgoingViewKey,
+                    publicAddress: decoded.publicAddress,
                   },
-                ],
-              },
-            );
+                );
+                console.log(JSON.stringify(result));
+              }}
+              title="Import Account"
+            />
+            <Button
+              onPress={async () => {
+                if (!account.data) return;
 
-            const txn = RawTransactionSerde.deserialize(
-              Buffer.from(result.transaction, "hex"),
-            );
+                const result = await OreowalletServerApi.getAccountStatus(
+                  Network.MAINNET,
+                  await getAccountInfo(account.data.name),
+                );
+                console.log(JSON.stringify(result));
+              }}
+              title="Get Account Status"
+            />
+            <Button
+              onPress={async () => {
+                if (!account.data) return;
 
-            const txnResult = await wallet.sendTransactionWithSpends(
-              Network.MAINNET,
-              account.data.name,
-              txn.version,
-              txn.fee.toString(),
-              txn.outputs.map(({ note }) => ({
-                amount: note.value().toString(),
-                assetId: note.assetId().toString("hex"),
-                publicAddress: note.owner(),
-                memoHex: note.memo().toString("hex"),
-              })),
-              txn.spends.map(({ note, witness }) => ({
-                note: note.serialize().toString("hex"),
-                witnessTreeSize: witness.treeSize().toString(),
-                witnessRootHash: witness.serializeRootHash().toString("hex"),
-                witnessAuthPath: witness.authPath().map((authPath) => ({
-                  hashOfSibling: authPath.hashOfSibling().toString("hex"),
-                  side: authPath.side(),
-                })),
-              })),
-            );
+                const result = await OreowalletServerApi.getTransactions(
+                  Network.MAINNET,
+                  await getAccountInfo(account.data.name),
+                );
+                console.log(JSON.stringify(result));
+              }}
+              title="Get Transactions"
+            />
+            <Button
+              onPress={async () => {
+                if (!account.data) return;
 
-            console.log(JSON.stringify(txnResult));
-          }}
-          title="Create Transaction"
-        />
-        <Button
-          onPress={async () => {
-            if (!account.data) return;
+                const result = await OreowalletServerApi.createTransaction(
+                  Network.MAINNET,
+                  await getAccountInfo(account.data.name),
+                  {
+                    outputs: [
+                      {
+                        // TODO: Insert an address here
+                        publicAddress: "",
+                        amount: "100",
+                        assetId: IRON_ASSET_ID_HEX,
+                      },
+                    ],
+                  },
+                );
 
-            const result = await OreowalletServerApi.rescanAccount(
-              Network.MAINNET,
-              { address: account.data.publicAddress },
-            );
-            console.log(JSON.stringify(result));
-          }}
-          title="Rescan Account"
-        />
-        <Button
-          onPress={async () => {
-            if (!account.data) return;
+                const txn = RawTransactionSerde.deserialize(
+                  Buffer.from(result.transaction, "hex"),
+                );
 
-            const result = await OreowalletServerApi.broadcastTransaction(
-              Network.MAINNET,
-              "0101000000000000000200000000000000000000000000000000000000000000000100000000000000fdf30c00779b9c6610112a2b08d97538db7665ab55bdef79f4a9a2db0e5e91c7ad46273cad88da83426e96ceb966c8602331909ab6a579b830fba45b6dca310275006e7d6710554fb750a5190adbb93768632751b48fd37cf009ad742fa8c913d5af5be0fc0e822bfc0144c054412524318a3bb561cf4bd026a36a8574d110ef577797451663f2f35d9655b7aa127af097c092d65471a1e1b990f9da3cab27ff85fa9441f2814f6c6ef2e38cb7b337577f3d22ac8d38b9d35426961da866235126a5ba254c409715d5e6680a664c510c7934d9ebee1cb265023e8c14769a6b34de5e5bc11727fce7a7a56acce579e911c8d6b63cab4269756dd33480c7e34c1140f59b81d1af53710bae78250f65db8f0fe11b2b91c8815e84146e62c5dc0322614b38098bca2701e9b86ec0eac02b3cb098166d6985ccd4a167babdde6320bd7378a1f18db685825018a6e12236cb18e51597b958d25727519494ea555c7ddc6a21ce9827f274a83a2a8bfd52516550edf6170da4a69185960a566d10143cd10c58bc088b96ad0a979fc0f25859655c0386c892a6da3e96d903c5e65ef2855b4dd2a2afd5c19d7a29b68da253031c5a8e3df2b0a012f24b8dcb04dbf66c9d8e8058c3684fc59d663f143e4df21c887e5cbd1034aeda45caf591ad07783081abd598bf34a1f24e55058b49260297a73e29c95f69d82c2f5f5193cdc2f66bf7c2a404c411d7c05e4c39d09ce53308ae492b45ebbbc36c8785a77f47790cfb52fadb0b1bbed4b269eaad5ce2005de4f96f9dc85bc846447ff4507fb457dbf91590ec117ffe27b935f6d8bd10e31adad68163fc8d15c5ec396a4528f1bc2b3381304521ce0582eac1b2fabf5f06adc79fc900578646569c8bbf4c3498465b0b7ef91a18c1bbdcf84d08c855dde1face5ba2d3e84622fbfb15b0498bd66aea19740902487372751c649603f590e12d2036e0ab115f0da2db79caa30dfdeaa3019b33e8a654b04895b9fca30e9af48605464c92b3d98f866fc3fbb84da0ff633e63de2f7e1e2bf504116d7c12f083360d8f71edf22ac41ca718676ffefe75aaabc9329a897c1f17738207ccd0a06d883aaac5e1fc1e9c71488f8c3cf13641896722ab8ae47e136eda58644a91f41ec49b50609c9818f76ff36da06268c29486f8c138f5588163b8721eda408607bf7cada51c2f4e5ea426aacb19836a4a0c06cfe9d65333d863915815c1b8d5887b3e8eecb67ca2494b3544ba3cc4c42c97d7ad1eed59ff111238008456c808874643123443ae63b2a9dd0570b709f2fe0bbf870675cbc926bdd0707474d1ee013830a66d2729e2a1a8c0076bc59728ac96e544fb74a11264ceef06ad009376aa894b80f02cffae5248e429e0cc0de50b182545797debaa65e154a5e868a1f7eb37aba6fa62107a2fc9919c71384cb49668bbeb528b0436cc10ad13a2c262d0f3565f56cb50e3c6220973279529b432ebe987b8c598b1f3ea33e40d5c056ebcbffcc9ef4e40fe43ad32a2a0650ae5bc88b3b4b34319ea9a22a57a391590053422cd7f808bcb19ab9f48165e285023f7459173945e8555b34896cd78331db5356ddd4215e6efa4a142d66c876e7ac9f224240fafc155c50bc7b9b4adc39f416565811028742b5613c62fa2bcd78bf30c4d8237c4586df435370e7703b65cdf52852f2e8ac8c7db4fcda612bb1d7b4407cf9df09bdf3be6b609061d53ee926244753a9934cfdef0c218548ad4eaaa610d0337df82c7c2a72e1432a1359fa42f074dc5184937f64622930fe607582fdde75710f7c9c1827e1b98ff4633d59eada865b02002f727f65ebada27c01a17d2d0aa7b6c93ff3efbac642e21e51bcaa2e7a40f8f688b72f11b625f8412cf3f33c0a5a4b532ed13143de3258511ae338d6dbd17bf5fc5e12b5ebb355c65454333faf8c93ca63267b54d74eab8ecac9528e1c6b6768b5cbd1dcae6dfd638c806909fecf22f9d9557c4678411504167dbca6d3435f941ef3242aa25323f7667795a0e42f0001c562cf631bbbc69459601d6689557d77bc6d504bc2b0e2c98d56bea3b624803467fe5f8bce3df1bde62b10c8729d95146cee92bb1dacb7c7b0002",
-            );
-            console.log(JSON.stringify(result));
-          }}
-          title="Broadcast Transaction"
-        />
+                const txnResult = await wallet.sendTransactionWithSpends(
+                  Network.MAINNET,
+                  account.data.name,
+                  txn.version,
+                  txn.fee.toString(),
+                  txn.outputs.map(({ note }) => ({
+                    amount: note.value().toString(),
+                    assetId: note.assetId().toString("hex"),
+                    publicAddress: note.owner(),
+                    memoHex: note.memo().toString("hex"),
+                  })),
+                  txn.spends.map(({ note, witness }) => ({
+                    note: note.serialize().toString("hex"),
+                    witnessTreeSize: witness.treeSize().toString(),
+                    witnessRootHash: witness
+                      .serializeRootHash()
+                      .toString("hex"),
+                    witnessAuthPath: witness.authPath().map((authPath) => ({
+                      hashOfSibling: authPath.hashOfSibling().toString("hex"),
+                      side: authPath.side(),
+                    })),
+                  })),
+                );
+
+                console.log(JSON.stringify(txnResult));
+              }}
+              title="Create Transaction"
+            />
+            <Button
+              onPress={async () => {
+                if (!account.data) return;
+
+                const result = await OreowalletServerApi.rescanAccount(
+                  Network.MAINNET,
+                  await getAccountInfo(account.data.name),
+                );
+                console.log(JSON.stringify(result));
+              }}
+              title="Rescan Account"
+            />
+            <Button
+              onPress={async () => {
+                if (!account.data) return;
+
+                const result = await OreowalletServerApi.broadcastTransaction(
+                  Network.MAINNET,
+                  await getAccountInfo(account.data.name),
+                  "0101000000000000000200000000000000000000000000000000000000000000000100000000000000fdf30c00779b9c6610112a2b08d97538db7665ab55bdef79f4a9a2db0e5e91c7ad46273cad88da83426e96ceb966c8602331909ab6a579b830fba45b6dca310275006e7d6710554fb750a5190adbb93768632751b48fd37cf009ad742fa8c913d5af5be0fc0e822bfc0144c054412524318a3bb561cf4bd026a36a8574d110ef577797451663f2f35d9655b7aa127af097c092d65471a1e1b990f9da3cab27ff85fa9441f2814f6c6ef2e38cb7b337577f3d22ac8d38b9d35426961da866235126a5ba254c409715d5e6680a664c510c7934d9ebee1cb265023e8c14769a6b34de5e5bc11727fce7a7a56acce579e911c8d6b63cab4269756dd33480c7e34c1140f59b81d1af53710bae78250f65db8f0fe11b2b91c8815e84146e62c5dc0322614b38098bca2701e9b86ec0eac02b3cb098166d6985ccd4a167babdde6320bd7378a1f18db685825018a6e12236cb18e51597b958d25727519494ea555c7ddc6a21ce9827f274a83a2a8bfd52516550edf6170da4a69185960a566d10143cd10c58bc088b96ad0a979fc0f25859655c0386c892a6da3e96d903c5e65ef2855b4dd2a2afd5c19d7a29b68da253031c5a8e3df2b0a012f24b8dcb04dbf66c9d8e8058c3684fc59d663f143e4df21c887e5cbd1034aeda45caf591ad07783081abd598bf34a1f24e55058b49260297a73e29c95f69d82c2f5f5193cdc2f66bf7c2a404c411d7c05e4c39d09ce53308ae492b45ebbbc36c8785a77f47790cfb52fadb0b1bbed4b269eaad5ce2005de4f96f9dc85bc846447ff4507fb457dbf91590ec117ffe27b935f6d8bd10e31adad68163fc8d15c5ec396a4528f1bc2b3381304521ce0582eac1b2fabf5f06adc79fc900578646569c8bbf4c3498465b0b7ef91a18c1bbdcf84d08c855dde1face5ba2d3e84622fbfb15b0498bd66aea19740902487372751c649603f590e12d2036e0ab115f0da2db79caa30dfdeaa3019b33e8a654b04895b9fca30e9af48605464c92b3d98f866fc3fbb84da0ff633e63de2f7e1e2bf504116d7c12f083360d8f71edf22ac41ca718676ffefe75aaabc9329a897c1f17738207ccd0a06d883aaac5e1fc1e9c71488f8c3cf13641896722ab8ae47e136eda58644a91f41ec49b50609c9818f76ff36da06268c29486f8c138f5588163b8721eda408607bf7cada51c2f4e5ea426aacb19836a4a0c06cfe9d65333d863915815c1b8d5887b3e8eecb67ca2494b3544ba3cc4c42c97d7ad1eed59ff111238008456c808874643123443ae63b2a9dd0570b709f2fe0bbf870675cbc926bdd0707474d1ee013830a66d2729e2a1a8c0076bc59728ac96e544fb74a11264ceef06ad009376aa894b80f02cffae5248e429e0cc0de50b182545797debaa65e154a5e868a1f7eb37aba6fa62107a2fc9919c71384cb49668bbeb528b0436cc10ad13a2c262d0f3565f56cb50e3c6220973279529b432ebe987b8c598b1f3ea33e40d5c056ebcbffcc9ef4e40fe43ad32a2a0650ae5bc88b3b4b34319ea9a22a57a391590053422cd7f808bcb19ab9f48165e285023f7459173945e8555b34896cd78331db5356ddd4215e6efa4a142d66c876e7ac9f224240fafc155c50bc7b9b4adc39f416565811028742b5613c62fa2bcd78bf30c4d8237c4586df435370e7703b65cdf52852f2e8ac8c7db4fcda612bb1d7b4407cf9df09bdf3be6b609061d53ee926244753a9934cfdef0c218548ad4eaaa610d0337df82c7c2a72e1432a1359fa42f074dc5184937f64622930fe607582fdde75710f7c9c1827e1b98ff4633d59eada865b02002f727f65ebada27c01a17d2d0aa7b6c93ff3efbac642e21e51bcaa2e7a40f8f688b72f11b625f8412cf3f33c0a5a4b532ed13143de3258511ae338d6dbd17bf5fc5e12b5ebb355c65454333faf8c93ca63267b54d74eab8ecac9528e1c6b6768b5cbd1dcae6dfd638c806909fecf22f9d9557c4678411504167dbca6d3435f941ef3242aa25323f7667795a0e42f0001c562cf631bbbc69459601d6689557d77bc6d504bc2b0e2c98d56bea3b624803467fe5f8bce3df1bde62b10c8729d95146cee92bb1dacb7c7b0002",
+                );
+                console.log(JSON.stringify(result));
+              }}
+              title="Broadcast Transaction"
+            />
+          </>
+        )}
       </View>
       <StatusBar style="auto" />
     </View>

--- a/packages/mobile-app/data/api/api.ts
+++ b/packages/mobile-app/data/api/api.ts
@@ -1,5 +1,5 @@
 import { Network } from "../constants";
-import { SerializedAsset } from "./types";
+import { SerializedAsset, SerializedHead } from "./types";
 
 const API_SERVER_URLS: Record<Network, string> = {
   [Network.MAINNET]: "https://api.ironfish.network/",
@@ -22,6 +22,16 @@ class IFApi {
     let assetDownload = (await fetchResult.json()) as SerializedAsset;
 
     return assetDownload;
+  }
+
+  async getHead(network: Network): Promise<SerializedHead> {
+    const url = API_SERVER_URLS[network] + `blocks/head`;
+    console.log(`requesting head: ${url}`);
+
+    const fetchResult = await fetch(url);
+    let head = (await fetchResult.json()) as SerializedHead;
+
+    return head;
   }
 }
 

--- a/packages/mobile-app/data/api/types.ts
+++ b/packages/mobile-app/data/api/types.ts
@@ -20,3 +20,22 @@ export interface SerializedVerifiedAssetMetadata {
   logo_uri?: string;
   website?: string;
 }
+
+export interface SerializedHead {
+  id: number;
+  hash: string;
+  sequence: number;
+  previous_block_hash: string;
+  main: boolean;
+  difficulty: number;
+  transactions_count: number;
+  timestamp: string;
+  graffiti: string;
+  size: number;
+  time_since_last_block_ms: number;
+  object: "block";
+  hash_rate: number;
+  reward: string;
+  circulating_supply: number;
+  total_supply: number;
+}

--- a/packages/mobile-app/data/facades/wallet/demoHandlers.ts
+++ b/packages/mobile-app/data/facades/wallet/demoHandlers.ts
@@ -255,9 +255,11 @@ export const walletDemoHandlers = f.facade<WalletHandlers>({
       ];
     },
   ),
-  getWalletStatus: f.handler.query(async () => {
-    return WALLET_STATUS;
-  }),
+  getWalletStatus: f.handler.query(
+    async ({ accountName }: { accountName: string }) => {
+      return WALLET_STATUS;
+    },
+  ),
   importAccount: f.handler.mutation(
     async ({ account, name }: { account: string; name: string }) => {
       const k = generateKey();

--- a/packages/mobile-app/data/facades/wallet/types.ts
+++ b/packages/mobile-app/data/facades/wallet/types.ts
@@ -139,7 +139,7 @@ export type WalletHandlers = {
   getTransaction: Query<
     (args: { accountName: string; hash: string }) => Transaction | null
   >;
-  getWalletStatus: Query<() => WalletStatus>;
+  getWalletStatus: Query<(args: { accountName: string }) => WalletStatus>;
   importAccount: Mutation<
     (args: { account: string; name?: string }) => Account
   >;

--- a/packages/mobile-app/data/facades/wallet/walletServerHandlers.ts
+++ b/packages/mobile-app/data/facades/wallet/walletServerHandlers.ts
@@ -306,10 +306,15 @@ export const walletHandlers = f.facade<WalletHandlers>({
       }));
     },
   ),
-  getWalletStatus: f.handler.query(async (): Promise<WalletStatus> => {
-    const block = await Blockchain.getLatestBlock(Network.TESTNET);
-    return { status: wallet.scanState.type, latestKnownBlock: block.sequence };
-  }),
+  getWalletStatus: f.handler.query(
+    async ({ accountName }: { accountName: string }): Promise<WalletStatus> => {
+      const block = await Blockchain.getLatestBlock(Network.TESTNET);
+      return {
+        status: wallet.scanState.type,
+        latestKnownBlock: block.sequence,
+      };
+    },
+  ),
   importAccount: f.handler.mutation(
     async ({
       account,

--- a/packages/mobile-app/data/oreowalletServerApi/oreowalletServerApi.ts
+++ b/packages/mobile-app/data/oreowalletServerApi/oreowalletServerApi.ts
@@ -1,4 +1,6 @@
 import { Network } from "../constants";
+import * as Crypto from "expo-crypto";
+import * as Uint8ArrayUtils from "../../utils/uint8Array";
 
 const OREOWALLET_SERVER_URLS: Record<Network, string> = {
   [Network.MAINNET]: "https://api.oreowallet.com/",
@@ -12,12 +14,14 @@ const OREOWALLET_SERVER_URLS: Record<Network, string> = {
 //   [Network.TESTNET]: "https://prover.oreowallet.com/",
 // };
 
+type OreowalletSuccessServerResponse<T> = {
+  data: T;
+  error: undefined;
+  code: number;
+};
+
 type OreowalletServerResponse<T> =
-  | {
-      data: T;
-      error: undefined;
-      code: number;
-    }
+  | OreowalletSuccessServerResponse<T>
   | {
       data: undefined;
       error: string;
@@ -128,10 +132,75 @@ type BroadcastTransactionResponse = {
 
 const LOG_REQUESTS = true;
 
+type AccountInfo = { publicAddress: string; viewKey: string };
+
 /**
  * Contains methods for making API requests to the Oreowallet server.
  */
 class OreowalletServer {
+  private viewKeyToAuthTokenCache: Map<string, string> = new Map();
+
+  private async getAuthToken(account: AccountInfo) {
+    let base64Token = this.viewKeyToAuthTokenCache.get(account.viewKey);
+    if (base64Token) return base64Token;
+
+    const hash = Uint8ArrayUtils.toHex(
+      new Uint8Array(
+        await Crypto.digest(
+          Crypto.CryptoDigestAlgorithm.SHA256,
+          Uint8ArrayUtils.fromHex(account.viewKey),
+        ),
+      ),
+    );
+    const token = `${account.publicAddress}:${hash}`;
+    base64Token = Buffer.from(token).toString("base64");
+    this.viewKeyToAuthTokenCache.set(account.viewKey, base64Token);
+
+    return base64Token;
+  }
+
+  private async fetchOreo<T>(
+    url: string,
+    options: {
+      method: "POST" | "GET";
+      account?: AccountInfo;
+      body?: unknown;
+    },
+  ): Promise<OreowalletServerResponse<T>> {
+    try {
+      const fetchResult = await fetch(url, {
+        method: options.method,
+        headers: {
+          "Content-Type": "application/json",
+          ...(options.account
+            ? {
+                Authorization: `Basic ${await this.getAuthToken(options.account)}`,
+              }
+            : {}),
+        },
+        ...(options.body ? { body: JSON.stringify(options.body) } : {}),
+      });
+
+      const responseText = await fetchResult.text();
+
+      if (!fetchResult.ok) {
+        throw new Error(responseText);
+      }
+
+      const result = JSON.parse(responseText) as OreowalletServerResponse<T>;
+
+      if (result.error) {
+        console.error(result.error);
+      }
+
+      return result;
+    } catch (e: unknown) {
+      console.log(url)
+      console.error(e instanceof Error ? e.message : JSON.stringify(e));
+      throw e;
+    }
+  }
+
   async importAccount(
     network: Network,
     account: {
@@ -146,18 +215,13 @@ class OreowalletServer {
     },
   ): Promise<ImportAccountResponse> {
     const url = OREOWALLET_SERVER_URLS[network] + "import";
-
     LOG_REQUESTS && console.log("[OreowalletServer] Calling importAccount");
 
-    const fetchResult = await fetch(url, {
+    const response = await this.fetchOreo<ImportAccountResponse>(url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(account),
+      body: account,
     });
-    const response =
-      (await fetchResult.json()) as OreowalletServerResponse<ImportAccountResponse>;
+
     if (!response.data) {
       // Code for "Account already exists"
       if (response.code === 601) {
@@ -165,51 +229,42 @@ class OreowalletServer {
       }
       throw new Error(response.error);
     }
-
     return response.data;
   }
 
   async removeAccount(
     network: Network,
-    account: { address: string },
+    account: AccountInfo,
   ): Promise<RemoveAccountResponse> {
     const url = OREOWALLET_SERVER_URLS[network] + `remove`;
-
     LOG_REQUESTS && console.log("[OreowalletServer] Calling removeAccount");
 
-    const fetchResult = await fetch(url, {
+    const response = await this.fetchOreo<RemoveAccountResponse>(url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(account),
+      account,
+      body: { account: account.publicAddress },
     });
-    const response =
-      (await fetchResult.json()) as OreowalletServerResponse<RemoveAccountResponse>;
+
     if (!response.data) {
       throw new Error(response.error);
     }
-
     return response.data;
   }
 
   async getAccountStatus(
     network: Network,
-    account: { address: string },
+    account: AccountInfo,
   ): Promise<AccountStatusResponse> {
     const url = OREOWALLET_SERVER_URLS[network] + `accountStatus`;
 
     LOG_REQUESTS && console.log("[OreowalletServer] Calling getAccountStatus");
 
-    const fetchResult = await fetch(url, {
+    const response = await this.fetchOreo<AccountStatusResponse>(url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ account: account.address }),
+      account,
+      body: { account: account.publicAddress },
     });
-    const response =
-      (await fetchResult.json()) as OreowalletServerResponse<AccountStatusResponse>;
+
     if (!response.data) {
       throw new Error(response.error);
     }
@@ -219,46 +274,38 @@ class OreowalletServer {
 
   async rescanAccount(
     network: Network,
-    account: { address: string },
+    account: AccountInfo,
   ): Promise<AccountStatusResponse> {
     const url = OREOWALLET_SERVER_URLS[network] + `rescan`;
-
     LOG_REQUESTS && console.log("[OreowalletServer] Calling rescanAccount");
 
-    const fetchResult = await fetch(url, {
+    const response = await this.fetchOreo<AccountStatusResponse>(url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ account: account.address }),
+      account,
+      body: { account: account.publicAddress },
     });
-    const response =
-      (await fetchResult.json()) as OreowalletServerResponse<AccountStatusResponse>;
+
     if (!response.data) {
       throw new Error(response.error);
     }
-
     return response.data;
   }
 
   async getBalances(
     network: Network,
-    address: string,
+    account: AccountInfo,
     confirmations: number = 2,
   ): Promise<GetBalancesResponse> {
     const url = OREOWALLET_SERVER_URLS[network] + `getBalances`;
 
     LOG_REQUESTS && console.log("[OreowalletServer] Calling getBalances");
 
-    const fetchResult = await fetch(url, {
+    const response = await this.fetchOreo<GetBalancesResponse>(url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ account: address, confirmations }),
+      account,
+      body: { account: account.publicAddress, confirmations },
     });
-    const response =
-      (await fetchResult.json()) as OreowalletServerResponse<GetBalancesResponse>;
+
     if (!response.data) {
       throw new Error(response.error);
     }
@@ -268,47 +315,38 @@ class OreowalletServer {
 
   async getTransactions(
     network: Network,
-    address: string,
+    account: AccountInfo,
     limit: number = 50,
   ): Promise<GetTransactionsResponse> {
     const url = OREOWALLET_SERVER_URLS[network] + `getTransactions`;
-
     LOG_REQUESTS && console.log("[OreowalletServer] Calling getTransactions");
 
-    const fetchResult = await fetch(url, {
+    const response = await this.fetchOreo<GetTransactionsResponse>(url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ account: address, limit }),
+      account,
+      body: { account: account.publicAddress, limit },
     });
-    const response =
-      (await fetchResult.json()) as OreowalletServerResponse<GetTransactionsResponse>;
+
     if (!response.data) {
       throw new Error(response.error);
     }
-
     return response.data;
   }
 
   async getTransaction(
     network: Network,
-    address: string,
+    account: AccountInfo,
     hash: string,
   ): Promise<OreowalletTransactionDetailed | undefined> {
     const url = OREOWALLET_SERVER_URLS[network] + `getTransaction`;
-
     LOG_REQUESTS && console.log("[OreowalletServer] Calling getTransaction");
 
-    const fetchResult = await fetch(url, {
+    const response = await this.fetchOreo<GetTransactionResponse>(url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ account: address, hash }),
+      account,
+      body: { account: account.publicAddress, hash },
     });
-    const response =
-      (await fetchResult.json()) as OreowalletServerResponse<GetTransactionResponse>;
+
     if (!response.data) {
       // Code for "Transaction not found for account"
       if (response.code === 611) {
@@ -316,7 +354,6 @@ class OreowalletServer {
       }
       throw new Error(response.error);
     }
-
     return response.data.transaction;
   }
 
@@ -325,9 +362,10 @@ class OreowalletServer {
 
     LOG_REQUESTS && console.log("[OreowalletServer] Calling getLatestBlock");
 
-    const fetchResult = await fetch(url);
-    const response =
-      (await fetchResult.json()) as OreowalletServerResponse<LatestBlockResponse>;
+    const response = await this.fetchOreo<LatestBlockResponse>(url, {
+      method: "GET",
+    });
+
     if (!response.data) {
       throw new Error(response.error);
     }
@@ -337,7 +375,7 @@ class OreowalletServer {
 
   async createTransaction(
     network: Network,
-    address: string,
+    account: AccountInfo,
     transactionParameters: {
       fee?: string;
       outputs?: Output[];
@@ -346,28 +384,23 @@ class OreowalletServer {
     },
   ): Promise<CreateTransactionResponse> {
     const url = OREOWALLET_SERVER_URLS[network] + `createTx`;
-
     LOG_REQUESTS && console.log("[OreowalletServer] Calling createTransaction");
 
-    const fetchResult = await fetch(url, {
+    const response = await this.fetchOreo<CreateTransactionResponse>(url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        account: address,
+      account,
+      body: {
+        account: account.publicAddress,
         outputs: transactionParameters.outputs ?? [],
         mints: transactionParameters.mints ?? [],
         burns: transactionParameters.burns ?? [],
         fee: transactionParameters.fee,
-      }),
+      },
     });
-    const response =
-      (await fetchResult.json()) as OreowalletServerResponse<CreateTransactionResponse>;
+
     if (!response.data) {
       throw new Error(response.error);
     }
-
     return response.data;
   }
 
@@ -376,25 +409,17 @@ class OreowalletServer {
     transaction: string,
   ): Promise<BroadcastTransactionResponse> {
     const url = OREOWALLET_SERVER_URLS[network] + `broadcastTx`;
-
     LOG_REQUESTS &&
       console.log("[OreowalletServer] Calling broadcastTransaction");
 
-    const fetchResult = await fetch(url, {
+    const response = await this.fetchOreo<BroadcastTransactionResponse>(url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        transaction,
-      }),
+      body: { transaction },
     });
-    const response =
-      (await fetchResult.json()) as OreowalletServerResponse<BroadcastTransactionResponse>;
+
     if (!response.data) {
       throw new Error(response.error);
     }
-
     return response.data;
   }
 }

--- a/packages/mobile-app/data/oreowalletServerApi/oreowalletServerApi.ts
+++ b/packages/mobile-app/data/oreowalletServerApi/oreowalletServerApi.ts
@@ -406,6 +406,7 @@ class OreowalletServer {
 
   async broadcastTransaction(
     network: Network,
+    account: AccountInfo,
     transaction: string,
   ): Promise<BroadcastTransactionResponse> {
     const url = OREOWALLET_SERVER_URLS[network] + `broadcastTx`;
@@ -414,6 +415,7 @@ class OreowalletServer {
 
     const response = await this.fetchOreo<BroadcastTransactionResponse>(url, {
       method: "POST",
+      account,
       body: { transaction },
     });
 

--- a/packages/mobile-app/data/oreowalletServerApi/oreowalletServerApi.ts
+++ b/packages/mobile-app/data/oreowalletServerApi/oreowalletServerApi.ts
@@ -195,7 +195,7 @@ class OreowalletServer {
 
       return result;
     } catch (e: unknown) {
-      console.log(url)
+      console.log(url);
       console.error(e instanceof Error ? e.message : JSON.stringify(e));
       throw e;
     }
@@ -357,13 +357,14 @@ class OreowalletServer {
     return response.data.transaction;
   }
 
-  async getLatestBlock(network: Network) {
+  async getLatestBlock(network: Network, account: AccountInfo) {
     const url = OREOWALLET_SERVER_URLS[network] + `latestBlock`;
 
     LOG_REQUESTS && console.log("[OreowalletServer] Calling getLatestBlock");
 
     const response = await this.fetchOreo<LatestBlockResponse>(url, {
       method: "GET",
+      account,
     });
 
     if (!response.data) {

--- a/packages/mobile-app/data/wallet/oreowalletWallet.ts
+++ b/packages/mobile-app/data/wallet/oreowalletWallet.ts
@@ -518,6 +518,7 @@ export class Wallet {
 
     const broadcastResult = await OreowalletServerApi.broadcastTransaction(
       network,
+      { publicAddress: account.publicAddress, viewKey: decodedAccount.viewKey },
       Uint8ArrayUtils.toHex(postedTransaction),
     );
 

--- a/packages/mobile-app/data/wallet/oreowalletWallet.ts
+++ b/packages/mobile-app/data/wallet/oreowalletWallet.ts
@@ -99,8 +99,13 @@ export class Wallet {
 
     if (!account) return;
 
+    const decodedAccount = decodeAccount(account.viewOnlyAccount, {
+      name: account.name,
+    });
+
     const status = await OreowalletServerApi.getAccountStatus(network, {
-      address: account.publicAddress,
+      publicAddress: account.publicAddress,
+      viewKey: decodedAccount.viewKey,
     });
 
     const balances = await this.getBalances(account.id, network);
@@ -124,13 +129,16 @@ export class Wallet {
 
     return await Promise.all(
       accounts.map(async (a) => {
-        console.log(`account ${a.publicAddress}`);
         const balances = await this.getBalances(a.id, network);
-        console.log("got balances");
-        const status = await OreowalletServerApi.getAccountStatus(network, {
-          address: a.publicAddress,
+
+        const decodedAccount = decodeAccount(a.viewOnlyAccount, {
+          name: a.name,
         });
-        console.log("got status");
+
+        const status = await OreowalletServerApi.getAccountStatus(network, {
+          publicAddress: a.publicAddress,
+          viewKey: decodedAccount.viewKey,
+        });
         return {
           ...a,
           head: status.account.head
@@ -158,9 +166,14 @@ export class Wallet {
 
     if (!account) return;
 
+    const decodedAccount = decodeAccount(account.viewOnlyAccount, {
+      name: account.name,
+    });
+
     const balances = await this.getBalances(account.id, network);
     const status = await OreowalletServerApi.getAccountStatus(network, {
-      address: account.publicAddress,
+      publicAddress: account.publicAddress,
+      viewKey: decodedAccount.viewKey,
     });
 
     return {
@@ -198,9 +211,13 @@ export class Wallet {
     const account = await this.state.db.getAccountById(accountId);
     if (!account) return [];
 
+    const decodedAccount = decodeAccount(account.viewOnlyAccount, {
+      name: account.name,
+    });
+
     const response = await OreowalletServerApi.getBalances(
       network,
-      account.publicAddress,
+      { publicAddress: account.publicAddress, viewKey: decodedAccount.viewKey },
       CONFIRMATIONS,
     );
 
@@ -290,9 +307,13 @@ export class Wallet {
       throw new Error(`No account found with name ${accountName}`);
     }
 
+    const decodedAccount = decodeAccount(account.viewOnlyAccount, {
+      name: account.name,
+    });
+
     const txn = await OreowalletServerApi.getTransaction(
       network,
-      account.publicAddress,
+      { publicAddress: account.publicAddress, viewKey: decodedAccount.viewKey },
       Uint8ArrayUtils.toHex(transactionHash),
     );
 
@@ -316,9 +337,13 @@ export class Wallet {
       throw new Error(`No account found with name ${accountName}`);
     }
 
+    const decodedAccount = decodeAccount(account.viewOnlyAccount, {
+      name: account.name,
+    });
+
     const results = await OreowalletServerApi.getTransactions(
       network,
-      account.publicAddress,
+      { publicAddress: account.publicAddress, viewKey: decodedAccount.viewKey },
       50,
     );
 
@@ -358,11 +383,18 @@ export class Wallet {
       throw new Error("Cannot send transactions from a view-only account");
     }
 
+    const decodedAccount = decodeAccount(account.viewOnlyAccount, {
+      name: account.name,
+    });
+
     // Attempt to fund the transaction
     const createTransactionResponse =
       await OreowalletServerApi.createTransaction(
         network,
-        account.publicAddress,
+        {
+          publicAddress: account.publicAddress,
+          viewKey: decodedAccount.viewKey,
+        },
         {
           outputs: outputs.map((output) => ({
             publicAddress: account.publicAddress,
@@ -408,12 +440,16 @@ export class Wallet {
       throw new Error("Cannot send transactions from a view-only account");
     }
 
+    const decodedAccount = decodeAccount(account.viewOnlyAccount, {
+      name: account.name,
+    });
+
     console.log(`Account fetched in: ${performance.now() - lastTime}ms`);
     lastTime = performance.now();
 
     const createTransactionResult = await OreowalletServerApi.createTransaction(
       network,
-      account.publicAddress,
+      { publicAddress: account.publicAddress, viewKey: decodedAccount.viewKey },
       {
         outputs,
         fee,

--- a/packages/mobile-app/package.json
+++ b/packages/mobile-app/package.json
@@ -16,6 +16,7 @@
     "data-facade": "*",
     "expo": "^52.0.0",
     "expo-constants": "~17.0.4",
+    "expo-crypto": "~14.0.2",
     "expo-font": "~13.0.3",
     "expo-linear-gradient": "~14.0.2",
     "expo-linking": "~7.0.4",


### PR DESCRIPTION
Generates the oreowallet auth header and adds it to calls.

Fixed since PR was opened:

* [x] Update the debug page to pass in the view key (not important for now)
* [x] oreowallet's getLatestBlock now requires authorization. Need to update all the callsites to pass in an account or just use the regular Iron Fish API if we don't have one.

