### PR TITLE
refactor: remove language and theme pages from menu layout

### DIFF
--- a/packages/mobile-app/app/menu/_layout.tsx
+++ b/packages/mobile-app/app/menu/_layout.tsx
@@ -22,18 +22,6 @@ export default function MenuLayout() {
         }}
       />
       <Stack.Screen
-        name="language/index"
-        options={{
-          title: "Language",
-        }}
-      />
-      <Stack.Screen
-        name="theme/index"
-        options={{
-          title: "Theme",
-        }}
-      />
-      <Stack.Screen
         name="network/index"
         options={{
           title: "Network",


### PR DESCRIPTION
Fixes a warning that pops up because these menu options no longer exist.