### PR TITLE
Hide scanning message when account head is within CONFIRMATIONS of latest

### DIFF
--- a/packages/mobile-app/app/(tabs)/index.tsx
+++ b/packages/mobile-app/app/(tabs)/index.tsx
@@ -25,6 +25,7 @@ import { useAccount } from "../../providers/AccountProvider";
 import { router } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { CurrencyUtils } from "@ironfish/sdk";
+import { CONFIRMATIONS } from "@/data/constants";
 
 const MenuIcon = (props: IconProps) => <Icon {...props} name="menu-outline" />;
 const SettingsIcon = (props: IconProps) => (
@@ -116,7 +117,11 @@ export default function Balances() {
     );
   }
 
-  const isSyncing = getWalletStatusResult.data?.status === "SCANNING";
+  const isSyncing =
+    account?.head?.sequence !== undefined &&
+    getWalletStatusResult.data?.latestKnownBlock !== undefined &&
+    account.head.sequence <
+      Math.max(getWalletStatusResult.data.latestKnownBlock - CONFIRMATIONS, 1);
   const syncProgress = isSyncing
     ? ((account?.head?.sequence ?? 0) /
         (getWalletStatusResult.data?.latestKnownBlock ?? 1)) *

--- a/packages/mobile-app/data/constants.ts
+++ b/packages/mobile-app/data/constants.ts
@@ -5,3 +5,6 @@ export enum Network {
 
 export const IRON_ASSET_ID_HEX =
   "51f33a2f14f92735e562dc658a5639279ddca3d5079a6d1242b2a588a9cbf44c";
+
+// TODO: Make confirmations configurable
+export const CONFIRMATIONS = 2;

--- a/packages/mobile-app/data/oreowalletServerApi/oreowalletServerApi.ts
+++ b/packages/mobile-app/data/oreowalletServerApi/oreowalletServerApi.ts
@@ -1,4 +1,4 @@
-import { Network } from "../constants";
+import { CONFIRMATIONS, Network } from "../constants";
 import * as Crypto from "expo-crypto";
 import * as Uint8ArrayUtils from "../../utils/uint8Array";
 
@@ -294,7 +294,7 @@ class OreowalletServer {
   async getBalances(
     network: Network,
     account: AccountInfo,
-    confirmations: number = 2,
+    confirmations: number = CONFIRMATIONS,
   ): Promise<GetBalancesResponse> {
     const url = OREOWALLET_SERVER_URLS[network] + `getBalances`;
 

--- a/packages/mobile-app/data/wallet/oreowalletWallet.ts
+++ b/packages/mobile-app/data/wallet/oreowalletWallet.ts
@@ -8,7 +8,7 @@ import {
   decodeAccount,
   encodeAccount,
 } from "@ironfish/sdk";
-import { IRON_ASSET_ID_HEX, Network } from "../constants";
+import { CONFIRMATIONS, IRON_ASSET_ID_HEX, Network } from "../constants";
 import * as Uint8ArrayUtils from "../../utils/uint8Array";
 import { AssetLoader } from "./assetLoader";
 import { Output } from "../facades/wallet/types";
@@ -30,9 +30,6 @@ function assertStarted(state: WalletState): asserts state is StartedState {
     throw new Error("Wallet is not started");
   }
 }
-
-// TODO: Make confirmations configurable
-const CONFIRMATIONS = 2;
 
 // Used when calculating a transaction's expiration sequence by adding it
 // to the latest block sequence returned from the API.

--- a/packages/mobile-app/data/wallet/wallet.ts
+++ b/packages/mobile-app/data/wallet/wallet.ts
@@ -11,7 +11,7 @@ import {
   encodeAccount,
 } from "@ironfish/sdk";
 import { ChainProcessor } from "../chainProcessor";
-import { Network } from "../constants";
+import { CONFIRMATIONS, Network } from "../constants";
 import * as Uint8ArrayUtils from "../../utils/uint8Array";
 import { LightBlock, LightTransaction } from "../walletServerApi/lightstreamer";
 import { WriteQueue } from "./writeQueue";
@@ -36,9 +36,6 @@ function assertStarted(state: WalletState): asserts state is StartedState {
     throw new Error("Wallet is not started");
   }
 }
-
-// TODO: Make confirmations configurable
-const CONFIRMATIONS = 2;
 
 // Used when calculating a transaction's expiration sequence by adding it
 // to the latest block sequence returned from the API.


### PR DESCRIPTION
Spent a bit thinking about adding support for this into the wallet class directly, but I'd like to avoid having to make another call to oreowallet for the account head, so I think the simplest approach will work fine for now
