### PR TITLE
Update ironfish SDK to 2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3913,29 +3913,31 @@
       "dev": true
     },
     "node_modules/@ironfish/rust-nodejs": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs/-/rust-nodejs-2.2.0.tgz",
-      "integrity": "sha512-xStPyoltT9lK3UKfju3lUnjgJHS+EYQO8Aapw/1NYSThdKNhFkUlY0tP2Gl2w5NYu7wRYjQUyg4RQPwFgiyVcQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs/-/rust-nodejs-2.9.0.tgz",
+      "integrity": "sha512-uZG+awPA3Mz730RH1+wRojYdG4D9B4e4PuAsQrGaUIuLFHXM7Ab70SNLhnCG8/0egJYXEWl74WyJO47qWh8s+w==",
+      "license": "MPL-2.0",
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@ironfish/rust-nodejs-darwin-arm64": "2.2.0",
-        "@ironfish/rust-nodejs-darwin-x64": "2.2.0",
-        "@ironfish/rust-nodejs-linux-arm64-gnu": "2.2.0",
-        "@ironfish/rust-nodejs-linux-arm64-musl": "2.2.0",
-        "@ironfish/rust-nodejs-linux-x64-gnu": "2.2.0",
-        "@ironfish/rust-nodejs-linux-x64-musl": "2.2.0",
-        "@ironfish/rust-nodejs-win32-x64-msvc": "2.2.0"
+        "@ironfish/rust-nodejs-darwin-arm64": "2.9.0",
+        "@ironfish/rust-nodejs-darwin-x64": "2.9.0",
+        "@ironfish/rust-nodejs-linux-arm64-gnu": "2.9.0",
+        "@ironfish/rust-nodejs-linux-arm64-musl": "2.9.0",
+        "@ironfish/rust-nodejs-linux-x64-gnu": "2.9.0",
+        "@ironfish/rust-nodejs-linux-x64-musl": "2.9.0",
+        "@ironfish/rust-nodejs-win32-x64-msvc": "2.9.0"
       }
     },
     "node_modules/@ironfish/rust-nodejs-darwin-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-2.2.0.tgz",
-      "integrity": "sha512-i/sDaHoNLEIYKZCXB8JRN0B+bSGl+BSXE5DFmuuFCmzf/c23ipPQ8hRW99wbIx2lzKYTzpmhVK0dQMcKJ/bzPQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-2.9.0.tgz",
+      "integrity": "sha512-s+ENuzTSw5aXrT5NTMgqV/++YLn/SPihytt7J3st1w078cz81ts7eCp66GRMEby6AmSDYlI29gnFUd8AEh9FyA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -3944,16 +3946,113 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@ironfish/rust-nodejs-darwin-x64": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-x64/-/rust-nodejs-darwin-x64-2.9.0.tgz",
+      "integrity": "sha512-wcEeySiptG6x+gYepAeeW/Btwym13PqF1ylIZQdARve0lyMuBgFKtgwZ/dq1mYsDK3PkQsZe94ioCsCPp/3ffQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@ironfish/rust-nodejs-linux-arm64-gnu": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-gnu/-/rust-nodejs-linux-arm64-gnu-2.9.0.tgz",
+      "integrity": "sha512-CHl31hkZf865ifmQt8KAolihgwwMxZ4h/odEHLHUAjfziYf84gZSlkVGwGPD6z/G9+xSnUQJlw6zq72M/UR8Xg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@ironfish/rust-nodejs-linux-arm64-musl": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-musl/-/rust-nodejs-linux-arm64-musl-2.9.0.tgz",
+      "integrity": "sha512-0dAwPdHJQBkFn/OnvD9eyMuCaySQ3vwY+1hH3oG/Ws7v906V0lYGhdqv5oKhKfw81wzRabrHeLTQ1NUp2CZQ0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@ironfish/rust-nodejs-linux-x64-gnu": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-gnu/-/rust-nodejs-linux-x64-gnu-2.9.0.tgz",
+      "integrity": "sha512-SObtiu7ZX3Yj23Lv/JL9CIvJWWdAQHnemNNY4xCL+Bc12caU567tADNew1JUTl9mFOkkCbvpTlRQMMKjDz7vBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@ironfish/rust-nodejs-linux-x64-musl": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-musl/-/rust-nodejs-linux-x64-musl-2.9.0.tgz",
+      "integrity": "sha512-fGgIKgxEqWnp5+Y3eO5WYRUPG7PxmPYSzJbs4CEkpEI8uksop2pRI+d2Tt8aOz1rcU4wj2prfYd/bGLoovB1PA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@ironfish/rust-nodejs-win32-x64-msvc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-win32-x64-msvc/-/rust-nodejs-win32-x64-msvc-2.9.0.tgz",
+      "integrity": "sha512-6iD9fglFQ4AGJELRB6FPhxHYf6t0la3pA9/FWMprVhtNCXGGk2P+5Z5FuAjrmFqmNRIxQL5q96JCNvdXH2fMQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@ironfish/sdk": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/sdk/-/sdk-2.2.0.tgz",
-      "integrity": "sha512-x4gaVRk2ZQyoPj9Ayi/N77qW8OpNRCXG0EEsUEI6drswgugYjqK86PRYsChanFMPdJpe0Gr1FNR3N/uagkYinw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/sdk/-/sdk-2.10.0.tgz",
+      "integrity": "sha512-6FDGCG+PlVB5sMo9dA29kju5Kc4YZ7Bqm0+hfPJ2aN3T14S0GkjgSieRakauWOlAXv4xyDIxVI9Iw4N0Wy8ThA==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@ethersproject/bignumber": "5.7.0",
         "@fast-csv/format": "4.3.5",
-        "@ironfish/rust-nodejs": "2.2.0",
+        "@ironfish/rust-nodejs": "2.9.0",
         "@napi-rs/blake-hash": "1.3.3",
-        "axios": "0.21.4",
+        "axios": "1.7.7",
         "bech32": "2.0.0",
         "blru": "0.1.6",
         "buffer": "6.0.3",
@@ -3967,16 +4066,17 @@
         "fastpriorityqueue": "0.7.1",
         "imurmurhash": "0.1.4",
         "level-errors": "2.0.1",
-        "leveldown": "5.6.0",
+        "leveldown": "6.1.1",
         "levelup": "4.4.0",
         "lodash": "4.17.21",
-        "node-datachannel": "0.5.1",
+        "nock": "13.5.4",
+        "node-datachannel": "0.8.0",
         "node-forge": "1.3.1",
         "parse-json": "5.2.0",
         "sqlite": "4.0.23",
         "sqlite3": "5.1.6",
         "uuid": "8.3.2",
-        "ws": "8.12.1",
+        "ws": "8.18.0",
         "yup": "0.29.3"
       },
       "engines": {
@@ -3984,11 +4084,14 @@
       }
     },
     "node_modules/@ironfish/sdk/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@ironfish/sdk/node_modules/buffer": {
@@ -4015,9 +4118,10 @@
       }
     },
     "node_modules/@ironfish/sdk/node_modules/ws": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
-      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -6021,6 +6125,188 @@
         "web-streams-polyfill": "^3.1.1"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.8.tgz",
+      "integrity": "sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.8.tgz",
+      "integrity": "sha512-Gigjz7mNWaOL9wCggvoK3jEIUUbGul656opstjaUSGC3eT0BM7PofdAJaBfPFWWkXNVAXbaQtC99OCg4sJv70Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.8.tgz",
+      "integrity": "sha512-02rVdZ5tgdUNRxIUrFdcMBZQoaPMrxtwSb+/hOfBdqkatYHR3lZ2A2EGyHq2sGOd0Owk80oV3snlDASC24He3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.8.tgz",
+      "integrity": "sha512-qIP/elwR/tq/dYRx3lgwK31jkZvMiD6qUtOycLhTzCvrjbZ3LjQnEM9rNhSGpbLXVJYQ3rq39A6Re0h9tU2ynw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.8.tgz",
+      "integrity": "sha512-IQNVXL9iY6NniYbTaOKdrlVP3XIqazBgJOVkddzJlqnCpRi/yAeSOa8PLcECFSQochzqApIOE1GHNu3pCz+BDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.8.tgz",
+      "integrity": "sha512-TYXcHghgnCqYFiE3FT5QwXtOZqDj5GmaFNTNt3jNC+vh22dc/ukG2cG+pi75QO4kACohZzidsq7yKTKwq/Jq7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.8.tgz",
+      "integrity": "sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.8.tgz",
+      "integrity": "sha512-S0lqKLfTm5u+QTxlFiAnb2J/2dgQqRy/XvziPtDd1rKZFXHTyYLoVL58M/XFwDI01AQCDIevGLbQrMAtdyanpA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.8.tgz",
+      "integrity": "sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.8.tgz",
+      "integrity": "sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.8.tgz",
+      "integrity": "sha512-NyF4gcxwkMFRjgXBM6g2lkT58OWztZvw5KkV2K0qqSnUEqCVcqdh2jN4gQrTn/YUpAcNKyFHfoOZEer9nwo6uQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.8.tgz",
+      "integrity": "sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.8.tgz",
+      "integrity": "sha512-xAQCAHPj8nJq1PI3z8CIZzXuXCstquz7cIOL73HHdXiRcKk8Ywwqtx2wrIy23EcTn4aZ2fLJNBB8d0tQENPCmw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.8.tgz",
+      "integrity": "sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.25.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.25.0.tgz",
@@ -6031,6 +6317,58 @@
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.8.tgz",
+      "integrity": "sha512-SCXcP0ZpGFIe7Ge+McxY5zKxiEI5ra+GT3QRxL0pMMtxPfpyLAKleZODi1zdRHkz5/BhueUrYtYVgubqe9JBNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.8.tgz",
+      "integrity": "sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.8.tgz",
+      "integrity": "sha512-r3NRQrXkHr4uWy5TOjTpTYojR9XmF0j/RYgKCef+Ag46FWUTltm5ziticv8LdNsDMehjJ543x/+TJAek/xBA2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.8.tgz",
+      "integrity": "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@rtsao/scc": {
@@ -6489,9 +6827,7 @@
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -8432,6 +8768,15 @@
         }
       ]
     },
+    "node_modules/catering": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -9279,6 +9624,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -11024,6 +11370,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
       }
@@ -11962,7 +12309,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
       "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -12217,7 +12563,8 @@
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.1.4",
@@ -14756,6 +15103,12 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -14909,18 +15262,106 @@
       }
     },
     "node_modules/leveldown": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.6.0.tgz",
-      "integrity": "sha512-iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.1.tgz",
+      "integrity": "sha512-88c+E+Eizn4CkQOBHwqlCJaTNEjGpaEIikn1S+cINc5E9HEvJ77bqY4JY/HxT5u0caWqsc3P3DcFIKBI1vHt+A==",
       "deprecated": "Superseded by classic-level (https://github.com/Level/community#faq)",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "abstract-leveldown": "~6.2.1",
+        "abstract-leveldown": "^7.2.0",
         "napi-macros": "~2.0.0",
-        "node-gyp-build": "~4.1.0"
+        "node-gyp-build": "^4.3.0"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/leveldown/node_modules/abstract-leveldown": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
+      "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "catering": "^2.0.0",
+        "is-buffer": "^2.0.5",
+        "level-concat-iterator": "^3.0.0",
+        "level-supports": "^2.0.1",
+        "queue-microtask": "^1.2.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/leveldown/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/leveldown/node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/leveldown/node_modules/level-concat-iterator": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
+      "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "license": "MIT",
+      "dependencies": {
+        "catering": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/leveldown/node_modules/level-supports": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
+      "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/levelup": {
@@ -15903,6 +16344,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -16122,7 +16564,8 @@
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/mobile-app": {
       "resolved": "packages/mobile-app",
@@ -16171,12 +16614,14 @@
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
     },
     "node_modules/napi-macros": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
-      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
+      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -16217,10 +16662,25 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/nock": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
+      "integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
     "node_modules/node-abi": {
       "version": "3.74.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.74.0.tgz",
       "integrity": "sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==",
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -16240,13 +16700,15 @@
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
     },
     "node_modules/node-datachannel": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.5.1.tgz",
-      "integrity": "sha512-3hwCrBWJqYoozwVtJNzNtISLKwa3l/XTbrPFCyhC3KCgW1IvYMHhHm5FW37p0p2oth3J6MDwCw3T/0m7DTR7lw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.8.0.tgz",
+      "integrity": "sha512-05vYthhjESfO5qumWRbqHI1PN71rc19DJjc14ofOLapJrTCnmhx0JYw0G5wcL56b57uHQP9WjEak3+XklrB+Og==",
       "hasInstallScript": true,
+      "license": "MPL 2.0",
       "dependencies": {
         "node-domexception": "^2.0.1",
-        "prebuild-install": "^7.0.1"
+        "prebuild-install": "^7.0.1",
+        "rollup": "^4.14.1"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -16297,6 +16759,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=16"
       }
@@ -16353,9 +16816,10 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
-      "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -17301,6 +17765,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -17326,6 +17791,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
@@ -17477,6 +17943,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/property-expr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
@@ -17508,8 +17983,7 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/prr": {
       "version": "1.0.1",
@@ -18497,6 +18971,57 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.8.tgz",
+      "integrity": "sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.6"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.34.8",
+        "@rollup/rollup-android-arm64": "4.34.8",
+        "@rollup/rollup-darwin-arm64": "4.34.8",
+        "@rollup/rollup-darwin-x64": "4.34.8",
+        "@rollup/rollup-freebsd-arm64": "4.34.8",
+        "@rollup/rollup-freebsd-x64": "4.34.8",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.34.8",
+        "@rollup/rollup-linux-arm-musleabihf": "4.34.8",
+        "@rollup/rollup-linux-arm64-gnu": "4.34.8",
+        "@rollup/rollup-linux-arm64-musl": "4.34.8",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.34.8",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.34.8",
+        "@rollup/rollup-linux-riscv64-gnu": "4.34.8",
+        "@rollup/rollup-linux-s390x-gnu": "4.34.8",
+        "@rollup/rollup-linux-x64-gnu": "4.34.8",
+        "@rollup/rollup-linux-x64-musl": "4.34.8",
+        "@rollup/rollup-win32-arm64-msvc": "4.34.8",
+        "@rollup/rollup-win32-ia32-msvc": "4.34.8",
+        "@rollup/rollup-win32-x64-msvc": "4.34.8",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.8.tgz",
+      "integrity": "sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -19050,7 +19575,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -19070,6 +19596,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -19839,6 +20366,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
       "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -19849,7 +20377,8 @@
     "node_modules/tar-fs/node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
@@ -20418,6 +20947,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -21500,7 +22030,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@eva-design/eva": "^2.2.0",
-        "@ironfish/sdk": "2.2.0",
+        "@ironfish/sdk": "2.10.0",
         "@react-navigation/drawer": "^7.1.1",
         "@ui-kitten/components": "^5.3.1",
         "@ui-kitten/eva-icons": "^5.3.1",

--- a/packages/ironfish-native-module/android/src/main/java/expo/modules/ironfishnativemodule/IronfishNativeModule.kt
+++ b/packages/ironfish-native-module/android/src/main/java/expo/modules/ironfishnativemodule/IronfishNativeModule.kt
@@ -110,6 +110,10 @@ class IronfishNativeModule : Module() {
       )
     }
 
+    Function("generatePublicAddressFromIncomingViewKey") { incomingViewKey: String ->
+      uniffi.rust_lib.generatePublicAddressFromIncomingViewKey(incomingViewKey)
+    }
+
     Function("isValidPublicAddress") { hexAddress: String ->
       uniffi.rust_lib.isValidPublicAddress(hexAddress)
     }

--- a/packages/ironfish-native-module/ios/IronfishNativeModule.swift
+++ b/packages/ironfish-native-module/ios/IronfishNativeModule.swift
@@ -111,6 +111,14 @@ public class IronfishNativeModule: Module {
       )
     }
 
+    Function("generatePublicAddressFromIncomingViewKey") { (incomingViewKey: String) throws -> String? in
+      guard let k = try? generatePublicAddressFromIncomingViewKey(incomingViewKey: incomingViewKey) else {
+        return nil
+      }
+
+      return k
+    }
+
     Function("isValidPublicAddress") { (hexAddress: String) -> Bool in
       return isValidPublicAddress(hexAddress: hexAddress)
     }

--- a/packages/ironfish-native-module/rust_lib/src/lib.rs
+++ b/packages/ironfish-native-module/rust_lib/src/lib.rs
@@ -13,10 +13,9 @@ use tokio_rayon::rayon::iter::{
 use zune_inflate::DeflateDecoder;
 
 use crate::num::FromPrimitive;
-use ironfish::sapling_bls12::Scalar;
 use ironfish::{
-    assets::asset::ID_LENGTH, keys::Language, note::MEMO_SIZE, serializing::bytes_to_hex,
-    MerkleNoteHash, Note, PublicAddress, SaplingKey,
+    assets::asset::ID_LENGTH, keys::Language, note::MEMO_SIZE, sapling_bls12::Scalar,
+    serializing::bytes_to_hex, IncomingViewKey, MerkleNoteHash, Note, PublicAddress, SaplingKey,
 };
 
 uniffi::setup_scaffolding!();
@@ -153,6 +152,16 @@ fn generate_key_from_private_key(private_key: String) -> Result<Key, EnumError> 
             &sapling_key.sapling_proof_generation_key().nsk.to_bytes(),
         ),
     })
+}
+
+#[uniffi::export]
+fn generate_public_address_from_incoming_view_key(
+    incoming_view_key: String,
+) -> Result<String, EnumError> {
+    let ivk = IncomingViewKey::from_hex(&incoming_view_key)
+        .map_err(|e| EnumError::Error { msg: e.to_string() })?;
+    let address = PublicAddress::from_view_key(&ivk);
+    Ok(address.hex_public_address())
 }
 
 #[uniffi::export]
@@ -413,8 +422,6 @@ pub fn create_transaction(
 }
 
 #[uniffi::export]
-pub fn hash_transaction(
-    transaction: Vec<u8>,
-) -> Vec<u8> {
+pub fn hash_transaction(transaction: Vec<u8>) -> Vec<u8> {
     blake3::hash(&transaction).as_bytes().to_vec()
 }

--- a/packages/ironfish-native-module/src/index.ts
+++ b/packages/ironfish-native-module/src/index.ts
@@ -47,6 +47,23 @@ export function generateKeyFromPrivateKey(privateKey: string): Key {
   }
 }
 
+export function generatePublicAddressFromIncomingViewKey(
+  incomingViewKey: string,
+): Key {
+  const result =
+    IronfishNativeModule.generatePublicAddressFromIncomingViewKey(
+      incomingViewKey,
+    );
+
+  // Throwing exceptions from expo modules directly logs to the console, even
+  // if the warning is caught.
+  if (result) {
+    return result;
+  } else {
+    throw new Error("Failed to generate public address from incoming view key");
+  }
+}
+
 export function isValidPublicAddress(hexAddress: string): boolean {
   return IronfishNativeModule.isValidPublicAddress(hexAddress);
 }

--- a/packages/mobile-app/app/(drawer)/app-settings/debug/oreowallet.tsx
+++ b/packages/mobile-app/app/(drawer)/app-settings/debug/oreowallet.tsx
@@ -5,7 +5,7 @@ import { OreowalletServerApi } from "@/data/oreowalletServerApi/oreowalletServer
 import { useFacade } from "@/data/facades";
 import {
   AccountFormat,
-  decodeAccount,
+  decodeAccountImport,
   RawTransactionSerde,
 } from "@ironfish/sdk";
 
@@ -22,7 +22,7 @@ export default function MenuDebugOreowallet() {
       viewOnly: true,
     });
 
-    const acc = decodeAccount(es);
+    const acc = decodeAccountImport(es);
 
     return { publicAddress: acc.publicAddress, viewKey: acc.viewKey };
   };
@@ -42,7 +42,7 @@ export default function MenuDebugOreowallet() {
                   format: AccountFormat.JSON,
                   viewOnly: true,
                 });
-                const decoded = decodeAccount(exported);
+                const decoded = decodeAccountImport(exported);
 
                 const result = await OreowalletServerApi.importAccount(
                   Network.MAINNET,

--- a/packages/mobile-app/data/debug/reverseScan.ts
+++ b/packages/mobile-app/data/debug/reverseScan.ts
@@ -1,4 +1,4 @@
-import { decodeAccount } from "@ironfish/sdk";
+import { decodeAccountImport } from "@ironfish/sdk";
 import { Network } from "../constants";
 import { Wallet } from "../wallet/wallet";
 import { WriteQueue } from "../wallet/writeQueue";
@@ -38,7 +38,7 @@ export async function reverseScan(
   for (const dbAccount of dbAccounts) {
     accounts.push({
       ...dbAccount,
-      decodedAccount: decodeAccount(dbAccount.viewOnlyAccount, {
+      decodedAccount: decodeAccountImport(dbAccount.viewOnlyAccount, {
         name: dbAccount.name,
       }),
     });

--- a/packages/mobile-app/data/facades/wallet/oreowalletHandlers.ts
+++ b/packages/mobile-app/data/facades/wallet/oreowalletHandlers.ts
@@ -16,7 +16,7 @@ import { SettingsKey } from "@/data/settings/db";
 
 import {
   AccountFormat,
-  decodeAccount,
+  decodeAccountImport,
   LanguageKey,
   LanguageUtils,
   TransactionStatus,
@@ -322,7 +322,7 @@ export const walletHandlers = f.facade<WalletHandlers>({
         },
       );
 
-      const decodedAccount = decodeAccount(exportedAcc);
+      const decodedAccount = decodeAccountImport(exportedAcc);
 
       const response = await OreowalletServerApi.getLatestBlock(network, {
         publicAddress: decodedAccount.publicAddress,

--- a/packages/mobile-app/data/wallet/db.ts
+++ b/packages/mobile-app/data/wallet/db.ts
@@ -1,9 +1,13 @@
-import { AccountImport } from "@ironfish/sdk/build/src/wallet/walletdb/accountValue";
 import { Kysely, Generated, Migrator, sql, Selectable } from "kysely";
 import { ExpoDialect, ExpoMigrationProvider, SQLiteType } from "kysely-expo";
 import * as SecureStore from "expo-secure-store";
 import * as FileSystem from "expo-file-system";
-import { AccountFormat, encodeAccount, Note } from "@ironfish/sdk";
+import {
+  AccountFormat,
+  encodeAccountImport,
+  Note,
+  AccountImport,
+} from "@ironfish/sdk";
 import { Network } from "../constants";
 import * as Uint8ArrayUtils from "../../utils/uint8Array";
 import { TransactionType } from "../facades/wallet/types";
@@ -477,7 +481,7 @@ export class WalletDb {
    * Returns the existing account if one already exists with the same public address.
    */
   async createAccount(account: AccountImport): Promise<DBAccount> {
-    const viewOnlyAccount = encodeAccount(
+    const viewOnlyAccount = encodeAccountImport(
       { ...account, spendingKey: null },
       AccountFormat.Base64Json,
     );

--- a/packages/mobile-app/data/wallet/oreowalletWallet.ts
+++ b/packages/mobile-app/data/wallet/oreowalletWallet.ts
@@ -5,8 +5,8 @@ import {
   LanguageKey,
   RawTransaction,
   RawTransactionSerde,
-  decodeAccount,
-  encodeAccount,
+  decodeAccountImport,
+  encodeAccountImport,
 } from "@ironfish/sdk";
 import { CONFIRMATIONS, IRON_ASSET_ID_HEX, Network } from "../constants";
 import * as Uint8ArrayUtils from "../../utils/uint8Array";
@@ -96,7 +96,7 @@ export class Wallet {
 
     if (!account) return;
 
-    const decodedAccount = decodeAccount(account.viewOnlyAccount, {
+    const decodedAccount = decodeAccountImport(account.viewOnlyAccount, {
       name: account.name,
     });
 
@@ -128,7 +128,7 @@ export class Wallet {
       accounts.map(async (a) => {
         const balances = await this.getBalances(a.id, network);
 
-        const decodedAccount = decodeAccount(a.viewOnlyAccount, {
+        const decodedAccount = decodeAccountImport(a.viewOnlyAccount, {
           name: a.name,
         });
 
@@ -163,7 +163,7 @@ export class Wallet {
 
     if (!account) return;
 
-    const decodedAccount = decodeAccount(account.viewOnlyAccount, {
+    const decodedAccount = decodeAccountImport(account.viewOnlyAccount, {
       name: account.name,
     });
 
@@ -208,7 +208,7 @@ export class Wallet {
     const account = await this.state.db.getAccountById(accountId);
     if (!account) return [];
 
-    const decodedAccount = decodeAccount(account.viewOnlyAccount, {
+    const decodedAccount = decodeAccountImport(account.viewOnlyAccount, {
       name: account.name,
     });
 
@@ -236,7 +236,7 @@ export class Wallet {
       throw new Error(`No account found with name ${name}`);
     }
 
-    const decodedAccount = decodeAccount(account.viewOnlyAccount, {
+    const decodedAccount = decodeAccountImport(account.viewOnlyAccount, {
       name,
     });
 
@@ -246,7 +246,7 @@ export class Wallet {
       );
     }
 
-    return encodeAccount(decodedAccount, format, {
+    return encodeAccountImport(decodedAccount, format, {
       language: options?.language,
     });
   }
@@ -254,7 +254,7 @@ export class Wallet {
   async importAccount(network: Network, account: string, name?: string) {
     assertStarted(this.state);
 
-    const decodedAccount = decodeAccount(account, {
+    const decodedAccount = decodeAccountImport(account, {
       name,
     });
 
@@ -310,7 +310,7 @@ export class Wallet {
       throw new Error(`No account found with name ${accountName}`);
     }
 
-    const decodedAccount = decodeAccount(account.viewOnlyAccount, {
+    const decodedAccount = decodeAccountImport(account.viewOnlyAccount, {
       name: account.name,
     });
 
@@ -340,7 +340,7 @@ export class Wallet {
       throw new Error(`No account found with name ${accountName}`);
     }
 
-    const decodedAccount = decodeAccount(account.viewOnlyAccount, {
+    const decodedAccount = decodeAccountImport(account.viewOnlyAccount, {
       name: account.name,
     });
 
@@ -436,7 +436,7 @@ export class Wallet {
       throw new Error("Cannot send transactions from a view-only account");
     }
 
-    const decodedAccount = decodeAccount(account.viewOnlyAccount, {
+    const decodedAccount = decodeAccountImport(account.viewOnlyAccount, {
       name: account.name,
     });
 
@@ -477,7 +477,7 @@ export class Wallet {
       throw new Error("Cannot send transactions from a view-only account");
     }
 
-    const decodedAccount = decodeAccount(account.viewOnlyAccount, {
+    const decodedAccount = decodeAccountImport(account.viewOnlyAccount, {
       name: account.name,
     });
 

--- a/packages/mobile-app/data/wallet/wallet.ts
+++ b/packages/mobile-app/data/wallet/wallet.ts
@@ -7,8 +7,8 @@ import {
   RawTransaction,
   Transaction,
   TransactionStatus,
-  decodeAccount,
-  encodeAccount,
+  decodeAccountImport,
+  encodeAccountImport,
 } from "@ironfish/sdk";
 import { ChainProcessor } from "../chainProcessor";
 import { CONFIRMATIONS, Network } from "../constants";
@@ -311,7 +311,7 @@ export class Wallet {
       throw new Error(`No account found with name ${name}`);
     }
 
-    const decodedAccount = decodeAccount(account.viewOnlyAccount, {
+    const decodedAccount = decodeAccountImport(account.viewOnlyAccount, {
       name,
     });
 
@@ -321,7 +321,7 @@ export class Wallet {
       );
     }
 
-    return encodeAccount(decodedAccount, format, {
+    return encodeAccountImport(decodedAccount, format, {
       language: options?.language,
     });
   }
@@ -329,7 +329,7 @@ export class Wallet {
   async importAccount(account: string, name?: string) {
     assertStarted(this.state);
 
-    const decodedAccount = decodeAccount(account, {
+    const decodedAccount = decodeAccountImport(account, {
       name,
     });
 
@@ -636,7 +636,7 @@ export class Wallet {
     for (const dbAccount of dbAccounts) {
       accounts.push({
         ...dbAccount,
-        decodedAccount: decodeAccount(dbAccount.viewOnlyAccount, {
+        decodedAccount: decodeAccountImport(dbAccount.viewOnlyAccount, {
           name: dbAccount.name,
         }),
       });
@@ -990,7 +990,7 @@ export class Wallet {
       }),
     );
 
-    const size = rawTxn.postedSize("");
+    const size = rawTxn.postedSize();
 
     const feeRates = await Blockchain.getFeeRates(Network.TESTNET);
 
@@ -1098,7 +1098,7 @@ export class Wallet {
     console.log(Uint8ArrayUtils.toHex(result));
 
     const txn = new Transaction(Buffer.from(result));
-    const decodedAccount = decodeAccount(account.viewOnlyAccount, {
+    const decodedAccount = decodeAccountImport(account.viewOnlyAccount, {
       name: account.name,
     });
 

--- a/packages/mobile-app/package.json
+++ b/packages/mobile-app/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@eva-design/eva": "^2.2.0",
-    "@ironfish/sdk": "2.2.0",
+    "@ironfish/sdk": "2.10.0",
     "@react-navigation/drawer": "^7.1.1",
     "@ui-kitten/components": "^5.3.1",
     "@ui-kitten/eva-icons": "^5.3.1",

--- a/packages/mobile-app/shims/ironfish-rust-nodejs.js
+++ b/packages/mobile-app/shims/ironfish-rust-nodejs.js
@@ -14,6 +14,8 @@ class Asset {
 
 class Transaction {}
 
+class Multisig {}
+
 const mockIronfishRustNodejs = {
   $$typeof: undefined,
   KEY_LENGTH: 32,
@@ -46,7 +48,17 @@ const mockIronfishRustNodejs = {
       if (obj.hasOwnProperty(property)) {
         return obj[property];
       }
-      const message = `ERROR: Please implement ${property} in shims/ironfish-rust-nodejs/Asset`;
+      const message = `ERROR: Please implement ${property} in shims/ironfish-rust-nodejs/Transaction`;
+      console.error(message);
+      throw new Error(message);
+    },
+  }),
+  multisig: new Proxy(Multisig, {
+    get: (obj, property) => {
+      if (obj.hasOwnProperty(property)) {
+        return obj[property];
+      }
+      const message = `ERROR: Please implement ${property} in shims/ironfish-rust-nodejs/Multisig`;
       console.error(message);
       throw new Error(message);
     },
@@ -54,6 +66,8 @@ const mockIronfishRustNodejs = {
   spendingKeyToWords: IronfishNativeModule.spendingKeyToWords,
   wordsToSpendingKey: IronfishNativeModule.wordsToSpendingKey,
   generateKeyFromPrivateKey: IronfishNativeModule.generateKeyFromPrivateKey,
+  generatePublicAddressFromIncomingViewKey:
+    IronfishNativeModule.generatePublicAddressFromIncomingViewKey,
   isValidPublicAddress: IronfishNativeModule.isValidPublicAddress,
 };
 


### PR DESCRIPTION
Updates the Iron Fish SDK to 2.10.0. This will require running `npm i` from the root directory, as well as rebuilding the rust code (Should be handled automatically by `nx ios` or `nx android`).
