### PR TITLE
Hardcode light theme for react navigation

### DIFF
--- a/packages/mobile-app/app/(drawer)/account/account-settings/account-select/index.tsx
+++ b/packages/mobile-app/app/(drawer)/account/account-settings/account-select/index.tsx
@@ -70,7 +70,6 @@ export default function AccountSelect() {
             Add Account
           </Button>
         </Layout>
-        <StatusBar style="auto" />
       </Layout>
     </>
   );

--- a/packages/mobile-app/app/(drawer)/account/account-settings/account-select/index.tsx
+++ b/packages/mobile-app/app/(drawer)/account/account-settings/account-select/index.tsx
@@ -1,4 +1,3 @@
-import { StatusBar } from "expo-status-bar";
 import { StyleSheet } from "react-native";
 import { Stack, useRouter } from "expo-router";
 import { useFacade } from "@/data/facades";

--- a/packages/mobile-app/app/(drawer)/account/account-settings/add-account/create.tsx
+++ b/packages/mobile-app/app/(drawer)/account/account-settings/add-account/create.tsx
@@ -26,7 +26,6 @@ export default function CreateAccount() {
           router.dismissAll();
         }}
       />
-      <StatusBar style="auto" />
     </View>
   );
 }

--- a/packages/mobile-app/app/(drawer)/account/account-settings/add-account/create.tsx
+++ b/packages/mobile-app/app/(drawer)/account/account-settings/add-account/create.tsx
@@ -1,4 +1,3 @@
-import { StatusBar } from "expo-status-bar";
 import { Button, StyleSheet, TextInput, View } from "react-native";
 import { useRouter } from "expo-router";
 import { useState } from "react";

--- a/packages/mobile-app/app/(drawer)/account/account-settings/add-account/index.tsx
+++ b/packages/mobile-app/app/(drawer)/account/account-settings/add-account/index.tsx
@@ -59,8 +59,6 @@ export default function AddAccount() {
           </Button>
         </Link>
       </Card>
-
-      <StatusBar style="auto" />
     </Layout>
   );
 }

--- a/packages/mobile-app/app/(drawer)/account/account-settings/add-account/index.tsx
+++ b/packages/mobile-app/app/(drawer)/account/account-settings/add-account/index.tsx
@@ -1,4 +1,3 @@
-import { StatusBar } from "expo-status-bar";
 import { StyleSheet } from "react-native";
 import { Stack, Link } from "expo-router";
 import { Layout, Text, Card, Button, Divider } from "@ui-kitten/components";

--- a/packages/mobile-app/app/(drawer)/account/account-settings/export-account/index.tsx
+++ b/packages/mobile-app/app/(drawer)/account/account-settings/export-account/index.tsx
@@ -175,8 +175,6 @@ export default function ExportAccount() {
             )}
           </Card>
         </Modal>
-
-        <StatusBar style="auto" />
       </View>
     </>
   );

--- a/packages/mobile-app/app/(drawer)/account/account-settings/export-account/index.tsx
+++ b/packages/mobile-app/app/(drawer)/account/account-settings/export-account/index.tsx
@@ -1,4 +1,3 @@
-import { StatusBar } from "expo-status-bar";
 import { StyleSheet, View } from "react-native";
 import { Stack } from "expo-router";
 import { useFacade } from "@/data/facades";

--- a/packages/mobile-app/app/(drawer)/account/account-settings/index.tsx
+++ b/packages/mobile-app/app/(drawer)/account/account-settings/index.tsx
@@ -1,4 +1,3 @@
-import { StatusBar } from "expo-status-bar";
 import {
   Icon,
   IconElement,

--- a/packages/mobile-app/app/(drawer)/account/account-settings/index.tsx
+++ b/packages/mobile-app/app/(drawer)/account/account-settings/index.tsx
@@ -139,7 +139,6 @@ function AccountSettingsContent({ accountName }: { accountName: string }) {
               />,
             )}
         </Menu>
-        <StatusBar style="auto" />
       </Layout>
     </>
   );

--- a/packages/mobile-app/app/(drawer)/account/index.tsx
+++ b/packages/mobile-app/app/(drawer)/account/index.tsx
@@ -321,7 +321,7 @@ export default function Balances() {
             </Layout>
           </Layout>
         </Animated.ScrollView>
-        <StatusBar style="auto" />
+        <StatusBar style="dark" />
       </View>
     </>
   );

--- a/packages/mobile-app/app/(drawer)/account/send/index.tsx
+++ b/packages/mobile-app/app/(drawer)/account/send/index.tsx
@@ -348,8 +348,6 @@ export default function Send() {
           </View>
         </Layout>
       </Modal>
-
-      <StatusBar style="auto" />
     </Layout>
   );
 }

--- a/packages/mobile-app/app/(drawer)/account/send/index.tsx
+++ b/packages/mobile-app/app/(drawer)/account/send/index.tsx
@@ -1,4 +1,3 @@
-import { StatusBar } from "expo-status-bar";
 import { StyleSheet, View } from "react-native";
 import { useFacade } from "@/data/facades";
 import { useState, useMemo } from "react";

--- a/packages/mobile-app/app/(drawer)/account/transaction/[hash].tsx
+++ b/packages/mobile-app/app/(drawer)/account/transaction/[hash].tsx
@@ -268,8 +268,6 @@ export default function TransactionDetails() {
           View on Explorer
         </Button>
       </View>
-
-      <StatusBar style="auto" />
     </Layout>
   );
 }

--- a/packages/mobile-app/app/(drawer)/account/transaction/[hash].tsx
+++ b/packages/mobile-app/app/(drawer)/account/transaction/[hash].tsx
@@ -1,4 +1,3 @@
-import { StatusBar } from "expo-status-bar";
 import { StyleSheet, View, Linking } from "react-native";
 import { useLocalSearchParams, Stack } from "expo-router";
 import React from "react";

--- a/packages/mobile-app/app/(drawer)/app-settings/debug/index.tsx
+++ b/packages/mobile-app/app/(drawer)/app-settings/debug/index.tsx
@@ -1,4 +1,3 @@
-import { StatusBar } from "expo-status-bar";
 import { StyleSheet } from "react-native";
 import { Network } from "@/data/constants";
 import { wallet } from "@/data/wallet/wallet";

--- a/packages/mobile-app/app/(drawer)/app-settings/debug/index.tsx
+++ b/packages/mobile-app/app/(drawer)/app-settings/debug/index.tsx
@@ -69,7 +69,6 @@ export default function MenuDebug() {
           Remove Blocks
         </Button>
       </Layout>
-      <StatusBar style="auto" />
     </Layout>
   );
 }

--- a/packages/mobile-app/app/(drawer)/app-settings/debug/oreowallet.tsx
+++ b/packages/mobile-app/app/(drawer)/app-settings/debug/oreowallet.tsx
@@ -148,7 +148,6 @@ export default function MenuDebugOreowallet() {
           </>
         )}
       </View>
-      <StatusBar style="auto" />
     </View>
   );
 }

--- a/packages/mobile-app/app/(drawer)/app-settings/debug/oreowallet.tsx
+++ b/packages/mobile-app/app/(drawer)/app-settings/debug/oreowallet.tsx
@@ -1,4 +1,3 @@
-import { StatusBar } from "expo-status-bar";
 import { Button, StyleSheet, Text, View } from "react-native";
 import { IRON_ASSET_ID_HEX, Network } from "@/data/constants";
 import { OreowalletServerApi } from "@/data/oreowalletServerApi/oreowalletServerApi";

--- a/packages/mobile-app/app/(drawer)/app-settings/debug/pending.tsx
+++ b/packages/mobile-app/app/(drawer)/app-settings/debug/pending.tsx
@@ -1,4 +1,3 @@
-import { StatusBar } from "expo-status-bar";
 import { Button, ScrollView, StyleSheet, Text, View } from "react-native";
 import { Network } from "@/data/constants";
 import { wallet } from "@/data/wallet/wallet";

--- a/packages/mobile-app/app/(drawer)/app-settings/debug/pending.tsx
+++ b/packages/mobile-app/app/(drawer)/app-settings/debug/pending.tsx
@@ -58,7 +58,6 @@ export default function MenuDebugPending() {
           </View>
         ))}
       </ScrollView>
-      <StatusBar style="auto" />
     </View>
   );
 }

--- a/packages/mobile-app/app/(drawer)/app-settings/debug/unspent.tsx
+++ b/packages/mobile-app/app/(drawer)/app-settings/debug/unspent.tsx
@@ -82,7 +82,6 @@ export default function MenuDebugUnspentNotes() {
           </View>
         ))}
       </ScrollView>
-      <StatusBar style="auto" />
     </View>
   );
 }

--- a/packages/mobile-app/app/(drawer)/app-settings/debug/unspent.tsx
+++ b/packages/mobile-app/app/(drawer)/app-settings/debug/unspent.tsx
@@ -1,4 +1,3 @@
-import { StatusBar } from "expo-status-bar";
 import { Button, ScrollView, StyleSheet, Text, View } from "react-native";
 import { IRON_ASSET_ID_HEX, Network } from "@/data/constants";
 import { wallet } from "@/data/wallet/wallet";

--- a/packages/mobile-app/app/(drawer)/app-settings/index.tsx
+++ b/packages/mobile-app/app/(drawer)/app-settings/index.tsx
@@ -67,7 +67,6 @@ export default function MenuScreen() {
           />
         ))}
       </Menu>
-      <StatusBar style="auto" />
     </Layout>
   );
 }

--- a/packages/mobile-app/app/(drawer)/app-settings/index.tsx
+++ b/packages/mobile-app/app/(drawer)/app-settings/index.tsx
@@ -1,4 +1,3 @@
-import { StatusBar } from "expo-status-bar";
 import { StyleSheet } from "react-native";
 import {
   Icon,

--- a/packages/mobile-app/app/(drawer)/app-settings/network/index.tsx
+++ b/packages/mobile-app/app/(drawer)/app-settings/network/index.tsx
@@ -1,4 +1,3 @@
-import { StatusBar } from "expo-status-bar";
 import {
   Button,
   Modal,

--- a/packages/mobile-app/app/(drawer)/app-settings/network/index.tsx
+++ b/packages/mobile-app/app/(drawer)/app-settings/network/index.tsx
@@ -126,7 +126,6 @@ export default function MenuNetwork() {
         </View>
       </View>
       <Button title="Change Network" onPress={() => setModalVisible(true)} />
-      <StatusBar style="auto" />
     </View>
   );
 }

--- a/packages/mobile-app/app/_layout.tsx
+++ b/packages/mobile-app/app/_layout.tsx
@@ -1,8 +1,4 @@
-import {
-  DarkTheme,
-  DefaultTheme,
-  ThemeProvider,
-} from "@react-navigation/native";
+import { DefaultTheme, ThemeProvider } from "@react-navigation/native";
 import { Stack } from "expo-router";
 import { ActivityIndicator, SafeAreaView, StyleSheet } from "react-native";
 import {
@@ -11,7 +7,7 @@ import {
   QueryClientProvider,
 } from "@tanstack/react-query";
 
-import { useColorScheme, Text } from "react-native";
+import { Text } from "react-native";
 import { FacadeProvider, useFacade } from "@/data/facades";
 import { useEffect, useState } from "react";
 import { useFonts } from "expo-font";
@@ -65,7 +61,6 @@ function DatabaseLoader({ children }: { children?: React.ReactNode }) {
 }
 
 export default function Layout() {
-  const scheme = useColorScheme();
   const [loaded] = useFonts({
     Favorit: require("../assets/fonts/ABCFavorit-Regular.otf"),
     FavoritExtended: require("../assets/fonts/ABCFavoritExtended-Regular.otf"),

--- a/packages/mobile-app/app/_layout.tsx
+++ b/packages/mobile-app/app/_layout.tsx
@@ -74,7 +74,7 @@ export default function Layout() {
   if (!loaded) return null;
 
   return (
-    <ThemeProvider value={scheme === "dark" ? DarkTheme : DefaultTheme}>
+    <ThemeProvider value={DefaultTheme}>
       <IconRegistry icons={EvaIconsPack} />
       <ApplicationProvider {...eva} theme={eva.light}>
         <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
React navigation was switching to dark theme (as well as the status bar), but ui-kitten is hardcoded to use light theme. Fixing the dark theme will take some effort, so for now we can just hardcode everything to light theme.
